### PR TITLE
client support tls connections

### DIFF
--- a/src/client/client-grpc.ts
+++ b/src/client/client-grpc.ts
@@ -6,11 +6,13 @@ import * as grpc from "@grpc/grpc-js";
 
 export class GrpcClient {
   private readonly _hostAddress: string;
+  private readonly _tls: boolean;
   private readonly _options: grpc.ChannelOptions;
   private _stub: stubs.TaskHubSidecarServiceClient;
 
-  constructor(hostAddress: string = "localhost:4001", options: grpc.ChannelOptions = {}) {
+  constructor(hostAddress: string = "localhost:4001", options: grpc.ChannelOptions = {}, useTLS: boolean = false) {
     this._hostAddress = hostAddress;
+    this._tls = useTLS;
     this._options = this._generateChannelOptions(options);
     this._stub = this._generateClient();
   }
@@ -20,8 +22,15 @@ export class GrpcClient {
   }
 
   _generateClient(): stubs.TaskHubSidecarServiceClient {
-    const channelCreds = grpc.credentials.createInsecure();
+    const channelCreds = this._generateCredentials();
     return new stubs.TaskHubSidecarServiceClient(this._hostAddress, channelCreds, this._options);
+  }
+
+  _generateCredentials(): grpc.ChannelCredentials {
+    if (this._tls) {
+      return grpc.ChannelCredentials.createSsl();
+    }
+    return grpc.ChannelCredentials.createInsecure();
   }
 
   _generateChannelOptions(options: grpc.ChannelOptions = {}): grpc.ChannelOptions {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -22,8 +22,8 @@ import * as grpc from "@grpc/grpc-js";
 export class TaskHubGrpcClient {
   private _stub: stubs.TaskHubSidecarServiceClient;
 
-  constructor(hostAddress?: string, option?: grpc.ChannelOptions) {
-    this._stub = new GrpcClient(hostAddress, option).stub;
+  constructor(hostAddress?: string, option?: grpc.ChannelOptions, useTLS?: boolean) {
+    this._stub = new GrpcClient(hostAddress, option, useTLS).stub;
   }
 
   async stop(): Promise<void> {

--- a/src/worker/task-hub-grpc-worker.ts
+++ b/src/worker/task-hub-grpc-worker.ts
@@ -21,13 +21,15 @@ export class TaskHubGrpcWorker {
   private _responseStream: grpc.ClientReadableStream<pb.WorkItem> | null;
   private _registry: Registry;
   private _hostAddress?: string;
+  private _tls?: boolean;
   private _grpcChannelOptions?: grpc.ChannelOptions;
   private _isRunning: boolean;
   private _stub: stubs.TaskHubSidecarServiceClient | null;
 
-  constructor(hostAddress?: string, options?: grpc.ChannelOptions) {
+  constructor(hostAddress?: string, options?: grpc.ChannelOptions, useTLS?: boolean) {
     this._registry = new Registry();
     this._hostAddress = hostAddress;
+    this._tls = useTLS;
     this._grpcChannelOptions = options;
     this._responseStream = null;
     this._isRunning = false;
@@ -97,7 +99,7 @@ export class TaskHubGrpcWorker {
    * Therefore, we open the stream and simply listen through the eventemitter behind the scenes
    */
   async start(): Promise<void> {
-    const client = new GrpcClient(this._hostAddress, this._grpcChannelOptions);
+    const client = new GrpcClient(this._hostAddress, this._grpcChannelOptions, this._tls);
 
     if (this._isRunning) {
       throw new Error("The worker is already running.");


### PR DESCRIPTION
This PR adds support for tls connections. The change is made in a non breaking manner by adding the parameter as an optional and at the end of the constructors, so existing client instantiations will continue compiling without problems.

The idea for this change is to use it in the Dapr js SDK for workflows... currently the normal Dapr js sdk supports TLS connections but the workflows SDK (based on durabletask) does not support TLS https://github.com/dapr/js-sdk/blob/main/src/workflow/client/DaprWorkflowClient.ts#L48