### PR TITLE
Fix a test case with a undefined result

### DIFF
--- a/src/worker/orchestration-executor.ts
+++ b/src/worker/orchestration-executor.ts
@@ -124,15 +124,12 @@ export class OrchestrationExecutor {
             // since we create an async iterator, we await the creation (so we can use await in the generator itself beside yield)
             const result = await fn(ctx, input);
 
-            // When a generator is passed this is
-            // [object AsyncGenerator]
-            const resultType = result?.toString();
-
-            const isAsyncGenerator = typeof result[Symbol.asyncIterator] === 'function';
+            const isAsyncGenerator = typeof result?.[Symbol.asyncIterator] === 'function';
             if (isAsyncGenerator) {
               // Start the orchestrator's generator function
               await ctx.run(result);
             } else {
+              const resultType = Object.prototype.toString.call(result);
               console.log(`An orchestrator was returned that doesn't schedule any tasks (type = ${resultType})`);
 
               // This is an orchestrator that doesn't schedule any tasks

--- a/test/e2e/orchestration.spec.ts
+++ b/test/e2e/orchestration.spec.ts
@@ -146,6 +146,9 @@ describe("Durable Functions", () => {
   }, 31000);
 
   it("should be able to use the sub-orchestration for fan-out", async () => {
+    const SUB_ORCHESTRATION_COUNT = 2;
+    const ACTIVITY_COUNT = 2;
+
     let activityCounter = 0;
 
     const increment = (_: ActivityContext) => {
@@ -163,7 +166,7 @@ describe("Durable Functions", () => {
       const tasks: Task<any>[] = [];
 
       for (let i = 0; i < count; i++) {
-        tasks.push(ctx.callSubOrchestrator(orchestratorChild, 3));
+        tasks.push(ctx.callSubOrchestrator(orchestratorChild, ACTIVITY_COUNT));
       }
 
       // Wait for all the sub-orchestrations to complete
@@ -175,13 +178,13 @@ describe("Durable Functions", () => {
     taskHubWorker.addOrchestrator(orchestratorParent);
     await taskHubWorker.start();
 
-    const id = await taskHubClient.scheduleNewOrchestration(orchestratorParent, 10);
+    const id = await taskHubClient.scheduleNewOrchestration(orchestratorParent, SUB_ORCHESTRATION_COUNT);
     const state = await taskHubClient.waitForOrchestrationCompletion(id, undefined, 30);
 
     expect(state);
     expect(state?.runtimeStatus).toEqual(OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
     expect(state?.failureDetails).toBeUndefined();
-    expect(activityCounter).toEqual(30);
+    expect(activityCounter).toEqual(SUB_ORCHESTRATION_COUNT * ACTIVITY_COUNT);
   }, 31000);
 
   it("should allow waiting for multiple external events", async () => {


### PR DESCRIPTION
# Root cause

If `result` is `undefined`, it should add a `?` after `result` to avoid the potential error.

```
  ● Durable Functions › should be able to run an empty orchestration

    expect(received).toBeUndefined()

    Received: {"_errorType": "TypeError", "_message": "Cannot read properties of undefined (reading 'Symbol(Symbol.asyncIterator)')", "_stackTrace": "TypeError: Cannot read properties of undefined (reading 'Symbol(Symbol.asyncIterator)')

      129 |             const resultType = result?.toString();
      130 |
    > 131 |             const isAsyncGenerator = typeof result[Symbol.asyncIterator] === 'function';
          |                                                   ^
      132 |             if (isAsyncGenerator) {
      133 |               // Start the orchestrator's generator function
      134 |               await ctx.run(result);
```

Ref: https://github.com/microsoft/durabletask-js/actions/runs/10032489350/job/27763486093

---

# Else

I add `Object.prototype.toString.call` to detect object class.
I think this way is more correct when referring to the MDN document.

Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString#using_tostring_to_detect_object_class