### PR TITLE
Update release workflow documentation and remove automated PR creation step

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -3,7 +3,7 @@
 # 1. Updates package versions in all package.json files
 # 2. Generates changelog from git diff between main and last release tag
 # 3. Creates a release branch and tag
-# 4. Opens a pull request for review
+# After the workflow completes, manually create a PR from the release branch to main.
 
 name: Prepare Release
 
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   prepare-release:
@@ -177,43 +176,6 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "Created branch $BRANCH_NAME and tag v${NEW_VERSION}"
 
-      - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_VERSION: ${{ steps.calc-version.outputs.new_version }}
-          BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
-          CHANGELOG_FILE: ${{ steps.changelog-diff.outputs.changelog_file }}
-        run: |
-          CHANGELOG_CONTENT=$(cat "$CHANGELOG_FILE")
-          
-          # Write PR body to a temp file to avoid YAML escaping issues
-          cat > /tmp/pr_body.md << EOF
-          ## Release v${NEW_VERSION}
-          
-          This PR prepares the release of version **${NEW_VERSION}** for all packages.
-          
-          **Packages Updated:**
-          - @microsoft/durabletask-js@${NEW_VERSION}
-          - @microsoft/durabletask-js-azuremanaged@${NEW_VERSION}
-          
-          **Changes Since Last Release:**
-          ${CHANGELOG_CONTENT}
-          
-          **Release Checklist:**
-          - [ ] Review version bumps in package.json files
-          - [ ] Review CHANGELOG.md updates
-          - [ ] Verify CI passes
-          - [ ] Merge this PR
-          - [ ] After merge, the official build pipeline will produce signed artifacts
-          - [ ] Download artifacts and publish to npm with appropriate tag
-          EOF
-          
-          gh pr create \
-            --title "Release v${NEW_VERSION}" \
-            --body-file /tmp/pr_body.md \
-            --base main \
-            --head "$BRANCH_NAME"
-
       - name: Summary
         run: |
           NEW_VERSION="${{ steps.calc-version.outputs.new_version }}"
@@ -225,4 +187,8 @@ jobs:
           echo "- **Branch**: ${BRANCH_NAME}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tag**: v${NEW_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "A pull request has been created. Review and merge to complete the release." >> $GITHUB_STEP_SUMMARY
+          echo "### Next Step: Create a Pull Request" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Manually create a PR from **${BRANCH_NAME}** → **main** with title: **Release v${NEW_VERSION}**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[Create PR](https://github.com/microsoft/durabletask-js/compare/main...${BRANCH_NAME}?expand=1&title=Release+v${NEW_VERSION})" >> $GITHUB_STEP_SUMMARY

--- a/doc/release_process.md
+++ b/doc/release_process.md
@@ -49,7 +49,15 @@ Use the **Prepare Release** GitHub Action to automate the release preparation pr
 4. **Updates CHANGELOG.md**: Adds a new version section with the discovered changes
 5. **Creates a release branch**: `release/vX.Y.Z`
 6. **Creates a release tag**: `vX.Y.Z`
-7. **Opens a pull request**: For review before merging to `main`
+
+### After the Workflow Completes
+
+The workflow summary will include a link to create a PR. You must **manually create a pull request** from the release branch (`release/vX.Y.Z`) to `main`:
+
+1. Go to the workflow run summary and click the **Create PR** link, or navigate to: `https://github.com/microsoft/durabletask-js/compare/main...release/vX.Y.Z`
+2. Set the PR title to `Release vX.Y.Z`
+3. Review the version bumps and changelog updates
+4. Merge the PR after CI passes
 
 After the PR is merged, follow the **Publishing** steps below to build and publish.
 


### PR DESCRIPTION
# Summary

## What changed?
-

## Why is this change needed?
-

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `CHANGELOG.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)

## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing

## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, Node.js version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
