### PR TITLE
fix: clear orchestrationQueueSet in InMemoryOrchestrationBackend.reset()

### DIFF
--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -382,6 +382,7 @@ export class InMemoryOrchestrationBackend {
   reset(): void {
     this.instances.clear();
     this.orchestrationQueue.length = 0;
+    this.orchestrationQueueSet.clear();
     this.activityQueue.length = 0;
     for (const waiters of this.stateWaiters.values()) {
       for (const waiter of waiters) {

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -286,4 +286,26 @@ describe("In-Memory Backend", () => {
     const state = await client.getOrchestrationState(id);
     expect(state).toBeUndefined();
   });
+
+  it("should allow reusing instance IDs after reset", async () => {
+    const orchestrator: TOrchestrator = async (_: OrchestrationContext, input: number) => {
+      return input * 2;
+    };
+
+    // Create an orchestration without starting the worker, so it stays in the queue
+    const instanceId = "reuse-test-id";
+    backend.createInstance(instanceId, getName(orchestrator), JSON.stringify(10));
+
+    // Reset while the orchestration is still queued (not yet processed)
+    backend.reset();
+
+    // Now create a new orchestration with the same instance ID and process it
+    worker.addOrchestrator(orchestrator);
+    await worker.start();
+
+    await client.scheduleNewOrchestration(orchestrator, 21, instanceId);
+    const state = await client.waitForOrchestrationCompletion(instanceId, true, 10);
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toEqual(JSON.stringify(42));
+  });
 });


### PR DESCRIPTION
Fix https://github.com/microsoft/durabletask-js/issues/125
The reset() method clears the orchestrationQueue array but does not clear the orchestrationQueueSet. When an orchestration is created and reset() is called before the orchestration is dequeued, the Set retains the stale instance ID. Any subsequent createInstance() call with the same ID after reset is silently skipped by enqueueOrchestration() because the Set still reports the ID as present.

This causes the orchestration to never be processed.

# Summary

## What changed?
-

## Why is this change needed?
-

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `CHANGELOG.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)

## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing

## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, Node.js version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
