### PR TITLE
Fix continueAsNew dropping fire-and-forget actions (sendEvent, signal…

### DIFF
--- a/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
+++ b/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
@@ -242,7 +242,6 @@ export class RuntimeOrchestrationContext extends OrchestrationContext {
 
   getActions(): pb.OrchestratorAction[] {
     if (this._completionStatus === pb.OrchestrationStatus.ORCHESTRATION_STATUS_CONTINUED_AS_NEW) {
-      // Only return the single completion actions when continuing-as-new
       let carryoverEvents: pb.HistoryEvent[] | null = null;
 
       if (this._saveEvents) {
@@ -266,7 +265,11 @@ export class RuntimeOrchestrationContext extends OrchestrationContext {
         carryoverEvents,
       );
 
-      return [action];
+      // Include fire-and-forget actions (sendEvent, signalEntity, etc.) that were
+      // scheduled before continueAsNew was called, consistent with setComplete/setFailed
+      const allActions = Object.values(this._pendingActions);
+      allActions.push(action);
+      return allActions;
     }
 
     return Object.values(this._pendingActions);

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -229,6 +229,49 @@ describe("In-Memory Backend", () => {
     expect(state?.serializedOutput).toEqual(JSON.stringify(5));
   });
 
+  it("should preserve sendEvent actions when continuing-as-new", async () => {
+    // Receiver orchestration that waits for an event
+    const receiver: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const value = yield ctx.waitForExternalEvent("ping");
+      return value;
+    };
+
+    // Sender orchestration that sends an event then continues-as-new
+    const sender: TOrchestrator = async (ctx: OrchestrationContext, input: { receiverId: string; iteration: number }) => {
+      if (input.iteration === 1) {
+        // On first iteration, send event to receiver then continue-as-new
+        ctx.sendEvent(input.receiverId, "ping", "hello from sender");
+        ctx.continueAsNew({ receiverId: input.receiverId, iteration: 2 }, false);
+      } else {
+        return "sender done";
+      }
+    };
+
+    worker.addOrchestrator(receiver);
+    worker.addOrchestrator(sender);
+    await worker.start();
+
+    // Start receiver first, then sender
+    const receiverId = await client.scheduleNewOrchestration(receiver);
+    await client.waitForOrchestrationStart(receiverId, false, 5);
+
+    const senderId = await client.scheduleNewOrchestration(sender, { receiverId, iteration: 1 });
+
+    // Wait for both to complete
+    const senderState = await client.waitForOrchestrationCompletion(senderId, true, 10);
+    const receiverState = await client.waitForOrchestrationCompletion(receiverId, true, 10);
+
+    // Sender should complete after continuing-as-new
+    expect(senderState).toBeDefined();
+    expect(senderState?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(senderState?.serializedOutput).toEqual(JSON.stringify("sender done"));
+
+    // Receiver should have received the event sent before continue-as-new
+    expect(receiverState).toBeDefined();
+    expect(receiverState?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(receiverState?.serializedOutput).toEqual(JSON.stringify("hello from sender"));
+  });
+
   it("should handle orchestration without activities", async () => {
     const orchestrator: TOrchestrator = async (_: OrchestrationContext, input: number) => {
       return input * 2;


### PR DESCRIPTION
Fix https://github.com/microsoft/durabletask-js/issues/124
Problem
When an orchestration calls sendEvent() or signalEntity() before continueAsNew(), those fire-and-forget actions are silently dropped.

File: packages/durabletask-js/src/worker/runtime-orchestration-context.ts

In getActions() (line 243), when the completion status is CONTINUED_AS_NEW, only the single continue-as-new completion action is returned, dropping all other pending actions (including fire-and-forget actions like sendEvent). This is inconsistent with setComplete() (line 195) and setFailed() (line 217), which both preserve pending fire-and-forget actions.

Both setComplete and setFailed have explicit comments:

Note: Do NOT clear pending actions here - fire-and-forget actions like sendEvent must be preserved and returned alongside the complete action

Root Cause
setContinuedAsNew() stores only flags (_newInput, _saveEvents) without adding the completion action to _pendingActions. Then getActions() creates a fresh completion action and returns [action] as the sole item, discarding everything in _pendingActions.

Fix Available
Branch: copilot-finds/bug/continue-as-new-drops-fire-and-forget-actions

The fix modifies getActions() to include all pending actions alongside the continue-as-new completion action. A new unit test verifies that sendEvent actions scheduled before continueAsNew are preserved and delivered.

# Summary

## What changed?
-

## Why is this change needed?
-

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `CHANGELOG.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)

## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing

## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, Node.js version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
