### PR TITLE
Enforce Azure Managed e2e tests in daily-code-review agent

### DIFF
--- a/.github/agents/daily-code-review.agent.md
+++ b/.github/agents/daily-code-review.agent.md
@@ -151,12 +151,15 @@ Example: `copilot-finds/bug/fix-unhandled-promise-rejection`
   - Would have caught the bug (for bug fixes)
   - Cover the previously uncovered path (for missing tests)
   - Verify the improvement works (for improvements)
-- **If the change affects orchestration, activity, entity, or client/worker behavior:**
-  Add **Azure Managed e2e test(s)** in `test/e2e-azuremanaged/` as well. Follow the
-  existing patterns there (uses `DurableTaskAzureManagedClientBuilder` /
+- **Azure Managed e2e tests (MANDATORY for behavioral changes):**
+  If the change affects orchestration, activity, entity, or client/worker behavior,
+  you **MUST** also add an **Azure Managed e2e test** in `test/e2e-azuremanaged/`.
+  Do NOT skip this — it is a hard requirement, not optional. Follow the existing
+  patterns (uses `DurableTaskAzureManagedClientBuilder` /
   `DurableTaskAzureManagedWorkerBuilder`, reads `DTS_CONNECTION_STRING` or
   `ENDPOINT`/`TASKHUB` env vars). Add the new test case to the appropriate existing
   spec file (e.g., `orchestration.spec.ts`, `entity.spec.ts`, `retry-advanced.spec.ts`).
+  If you cannot add the e2e test, explain in the PR body **why** it was not feasible.
 - Keep changes minimal and focused — one concern per PR
 
 ### Labels
@@ -182,6 +185,11 @@ Before opening each PR, you MUST:
    - Your new tests must be in the appropriate test directory
    - They must follow existing test patterns and conventions
    - They must actually test the fix (not just exist)
+
+4. **Verify Azure Managed e2e tests were added (if applicable):**
+   - If your change affects orchestration, activity, entity, or client/worker behavior,
+     confirm you added a test in `test/e2e-azuremanaged/`
+   - If you did not, you must either add one or document in the PR body why it was not feasible
 
 **If any tests fail or lint errors appear:**
 - Fix them if they're caused by your changes


### PR DESCRIPTION
Make the requirement for Azure Managed e2e tests explicit and mandatory when behavioral changes are made. The agent was frequently skipping these tests. Changes:

- Mark Azure Managed e2e tests as MANDATORY (not just suggested)
- Add quality gate step to verify e2e tests were included
- Require justification in PR body if e2e tests are not feasible

# Summary

## What changed?
-

## Why is this change needed?
-

## Issues / work items
- Resolves #
- Related #

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `CHANGELOG.md`
- [ ] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [ ] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)

## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [ ] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s):
- AI-assisted areas/files:
- What you changed after AI output:

AI verification (required if AI was used):
- [ ] I understand the code and can explain it
- [ ] I verified referenced APIs/types exist and are correct
- [ ] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [ ] I reviewed concurrency/async behavior
- [ ] I checked for unintended breaking or behavior changes

---

# Testing

## Automated tests
- Result: Passed / Failed (link logs if failed)

## Manual validation (only if runtime/behavior changed)
- Environment (OS, Node.js version, components):
- Steps + observed results:
  1.
  2.
  3.
- Evidence (optional):

---

# Notes for reviewers
- N/A
