### PR TITLE
fix: Reset customStatus on continue-as-new in InMemoryOrchestrationBackend

### DIFF
--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -481,6 +481,7 @@ export class InMemoryOrchestrationBackend {
       instance.history = [];
       instance.input = newInput;
       instance.output = undefined;
+      instance.customStatus = undefined;
       instance.failureDetails = undefined;
       instance.status = pb.OrchestrationStatus.ORCHESTRATION_STATUS_PENDING;
 

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -229,6 +229,32 @@ describe("In-Memory Backend", () => {
     expect(state?.serializedOutput).toEqual(JSON.stringify(5));
   });
 
+  it("should clear customStatus after continue-as-new", async () => {
+    const orchestrator: TOrchestrator = async (ctx: OrchestrationContext, input: number) => {
+      if (input === 1) {
+        // First iteration: set a custom status then continue-as-new
+        ctx.setCustomStatus("iteration-1-status");
+        ctx.continueAsNew(2, false);
+      } else {
+        // Second iteration: do NOT set custom status — it should be cleared
+        return "done";
+      }
+    };
+
+    worker.addOrchestrator(orchestrator);
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator, 1);
+    const state = await client.waitForOrchestrationCompletion(id, true, 10);
+
+    expect(state).toBeDefined();
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toEqual(JSON.stringify("done"));
+    // customStatus must be cleared after continue-as-new when the new iteration
+    // does not set one — it should not carry over from the previous iteration
+    expect(state?.serializedCustomStatus).toBeUndefined();
+  });
+
   it("should preserve sendEvent actions when continuing-as-new", async () => {
     // Receiver orchestration that waits for an event
     const receiver: TOrchestrator = async function* (ctx: OrchestrationContext): any {


### PR DESCRIPTION
## Summary

Fixes #152

**Bug:** In `InMemoryOrchestrationBackend.processCompleteOrchestrationAction()`, when processing a `CONTINUED_AS_NEW` status, the `customStatus` field is not reset to `undefined`. Every other state field (`history`, `input`, `output`, `failureDetails`, `status`) is properly reset, but `customStatus` was overlooked. This causes stale custom status values to leak across continue-as-new boundaries in tests.

## Changes

- **`packages/durabletask-js/src/testing/in-memory-backend.ts`** — Added `instance.customStatus = undefined` to the continue-as-new reset block
- **`packages/durabletask-js/test/in-memory-backend.spec.ts`** — Added test verifying customStatus is cleared after continue-as-new

## Testing

All tests pass. Lint clean.
