### PR TITLE
fix: Validate first yielded value in orchestrator run() method

### DIFF
--- a/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
+++ b/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
@@ -109,8 +109,7 @@ export class RuntimeOrchestrationContext extends OrchestrationContext {
   async run(generator: Generator<Task<any>, any, any>) {
     this._generator = generator;
 
-    // TODO: do something with this task
-    // start the generator
+    // Start the generator
     const { value, done } = await this._generator.next();
 
     // if the generator finished, complete the orchestration.
@@ -119,12 +118,15 @@ export class RuntimeOrchestrationContext extends OrchestrationContext {
       return;
     }
 
-    // TODO: check if the task is null?
+    if (!(value instanceof Task)) {
+      throw new Error("The orchestrator generator yielded a non-Task object");
+    }
+
     this._previousTask = value;
 
     // If the yielded task is already complete (e.g., whenAll with an empty array),
     // resume immediately so the generator can continue.
-    if (this._previousTask instanceof Task && this._previousTask.isComplete) {
+    if (this._previousTask.isComplete) {
       await this.resume();
     }
   }

--- a/packages/durabletask-js/test/orchestration_executor.spec.ts
+++ b/packages/durabletask-js/test/orchestration_executor.spec.ts
@@ -1549,6 +1549,82 @@ describe("Orchestration Executor", () => {
     expect(completeAction?.getResult()?.getValue()).toEqual(JSON.stringify(expectedResult));
   });
 
+  it("should fail when orchestrator yields null as its first value", async () => {
+    // An orchestrator that yields null instead of a Task should fail with a clear error
+    const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
+      yield null;
+    };
+
+    const registry = new Registry();
+    const name = registry.addOrchestrator(badOrchestrator);
+    const newEvents = [
+      newOrchestratorStartedEvent(),
+      newExecutionStartedEvent(name, TEST_INSTANCE_ID, undefined),
+    ];
+    const executor = new OrchestrationExecutor(registry, testLogger);
+    const result = await executor.execute(TEST_INSTANCE_ID, [], newEvents);
+    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
+    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
+    expect(completeAction?.getFailuredetails()?.getErrormessage()).toContain("non-Task");
+  });
+
+  it("should fail when orchestrator yields undefined as its first value", async () => {
+    // An orchestrator that yields undefined instead of a Task should fail with a clear error
+    const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
+      yield undefined;
+    };
+
+    const registry = new Registry();
+    const name = registry.addOrchestrator(badOrchestrator);
+    const newEvents = [
+      newOrchestratorStartedEvent(),
+      newExecutionStartedEvent(name, TEST_INSTANCE_ID, undefined),
+    ];
+    const executor = new OrchestrationExecutor(registry, testLogger);
+    const result = await executor.execute(TEST_INSTANCE_ID, [], newEvents);
+    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
+    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
+    expect(completeAction?.getFailuredetails()?.getErrormessage()).toContain("non-Task");
+  });
+
+  it("should fail when orchestrator yields a plain object as its first value", async () => {
+    // An orchestrator that yields a non-Task object should fail with a clear error
+    const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
+      yield { someProperty: "not a task" };
+    };
+
+    const registry = new Registry();
+    const name = registry.addOrchestrator(badOrchestrator);
+    const newEvents = [
+      newOrchestratorStartedEvent(),
+      newExecutionStartedEvent(name, TEST_INSTANCE_ID, undefined),
+    ];
+    const executor = new OrchestrationExecutor(registry, testLogger);
+    const result = await executor.execute(TEST_INSTANCE_ID, [], newEvents);
+    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
+    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
+    expect(completeAction?.getFailuredetails()?.getErrormessage()).toContain("non-Task");
+  });
+
+  it("should fail when orchestrator yields a primitive as its first value", async () => {
+    // An orchestrator that yields a primitive (number) instead of a Task should fail
+    const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
+      yield 42;
+    };
+
+    const registry = new Registry();
+    const name = registry.addOrchestrator(badOrchestrator);
+    const newEvents = [
+      newOrchestratorStartedEvent(),
+      newExecutionStartedEvent(name, TEST_INSTANCE_ID, undefined),
+    ];
+    const executor = new OrchestrationExecutor(registry, testLogger);
+    const result = await executor.execute(TEST_INSTANCE_ID, [], newEvents);
+    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
+    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
+    expect(completeAction?.getFailuredetails()?.getErrormessage()).toContain("non-Task");
+  });
+
   it("should propagate inner whenAll failure to outer whenAny in nested composites", async () => {
     const hello = (_: any, name: string) => {
       return `Hello ${name}!`;

--- a/packages/durabletask-js/test/orchestration_executor.spec.ts
+++ b/packages/durabletask-js/test/orchestration_executor.spec.ts
@@ -1549,43 +1549,30 @@ describe("Orchestration Executor", () => {
     expect(completeAction?.getResult()?.getValue()).toEqual(JSON.stringify(expectedResult));
   });
 
-  it("should fail when orchestrator yields null as its first value", async () => {
-    // An orchestrator that yields null instead of a Task should fail with a clear error
-    const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
-      yield null;
-    };
+  it.each([
+    { description: "null", yieldedValue: null as any },
+    { description: "undefined", yieldedValue: undefined as any },
+  ])(
+    "should fail when orchestrator yields $description as its first value",
+    async ({ description, yieldedValue }) => {
+      // An orchestrator that yields a non-Task value as its first yield should fail with a clear error
+      const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
+        yield yieldedValue;
+      };
 
-    const registry = new Registry();
-    const name = registry.addOrchestrator(badOrchestrator);
-    const newEvents = [
-      newOrchestratorStartedEvent(),
-      newExecutionStartedEvent(name, TEST_INSTANCE_ID, undefined),
-    ];
-    const executor = new OrchestrationExecutor(registry, testLogger);
-    const result = await executor.execute(TEST_INSTANCE_ID, [], newEvents);
-    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
-    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
-    expect(completeAction?.getFailuredetails()?.getErrormessage()).toContain("non-Task");
-  });
-
-  it("should fail when orchestrator yields undefined as its first value", async () => {
-    // An orchestrator that yields undefined instead of a Task should fail with a clear error
-    const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
-      yield undefined;
-    };
-
-    const registry = new Registry();
-    const name = registry.addOrchestrator(badOrchestrator);
-    const newEvents = [
-      newOrchestratorStartedEvent(),
-      newExecutionStartedEvent(name, TEST_INSTANCE_ID, undefined),
-    ];
-    const executor = new OrchestrationExecutor(registry, testLogger);
-    const result = await executor.execute(TEST_INSTANCE_ID, [], newEvents);
-    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
-    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
-    expect(completeAction?.getFailuredetails()?.getErrormessage()).toContain("non-Task");
-  });
+      const registry = new Registry();
+      const name = registry.addOrchestrator(badOrchestrator);
+      const newEvents = [
+        newOrchestratorStartedEvent(),
+        newExecutionStartedEvent(name, TEST_INSTANCE_ID, undefined),
+      ];
+      const executor = new OrchestrationExecutor(registry, testLogger);
+      const result = await executor.execute(TEST_INSTANCE_ID, [], newEvents);
+      const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
+      expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
+      expect(completeAction?.getFailuredetails()?.getErrormessage()).toContain("non-Task");
+    }
+  );
 
   it("should fail when orchestrator yields a plain object as its first value", async () => {
     // An orchestrator that yields a non-Task object should fail with a clear error

--- a/packages/durabletask-js/test/orchestration_executor.spec.ts
+++ b/packages/durabletask-js/test/orchestration_executor.spec.ts
@@ -1554,7 +1554,7 @@ describe("Orchestration Executor", () => {
     { description: "undefined", yieldedValue: undefined as any },
   ])(
     "should fail when orchestrator yields $description as its first value",
-    async ({ description, yieldedValue }) => {
+    async ({ description: _description, yieldedValue }) => {
       // An orchestrator that yields a non-Task value as its first yield should fail with a clear error
       const badOrchestrator: TOrchestrator = async function* (_ctx: OrchestrationContext): any {
         yield yieldedValue;


### PR DESCRIPTION
## Summary
Add validation that the first value yielded by an orchestrator generator is a Task instance, matching the existing validation in esume().

Closes #160

## Problem
un() silently accepts any value (null, undefined, plain objects, primitives) as the first yield and assigns it to _previousTask without validation. This causes orchestrations to hang indefinitely with no error when a non-Task value is yielded.

## Fix
Add the same instanceof Task validation that esume() already has, replacing the TODO comment that acknowledged this gap.