### PR TITLE
fix: Preserve original URL parsing error cause in getHostAddress()

### DIFF
--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -101,8 +101,8 @@ abstract class DurableTaskAzureManagedOptionsBase {
         authority = `${authority}:${url.port}`;
       }
       return authority;
-    } catch {
-      throw new Error(`Invalid endpoint URL: ${endpoint}`);
+    } catch (e) {
+      throw new Error(`Invalid endpoint URL: ${endpoint}`, { cause: e });
     }
   }
 

--- a/packages/durabletask-js-azuremanaged/test/unit/options.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/options.spec.ts
@@ -158,6 +158,23 @@ describe("Options", () => {
 
         expect(() => options.getHostAddress()).toThrow("Invalid endpoint URL:");
       });
+
+      it("should preserve the original error as cause when URL parsing fails", () => {
+        const options = new DurableTaskAzureManagedClientOptions().setEndpointAddress("invalid:url");
+
+        try {
+          options.getHostAddress();
+          fail("Expected getHostAddress to throw");
+        } catch (e: unknown) {
+          expect(e).toBeInstanceOf(Error);
+          const error = e as Error;
+          expect(error.message).toContain("Invalid endpoint URL:");
+          expect(error.cause).toBeDefined();
+          // The cause should be the original URL parsing error
+          expect((error.cause as Error).message).toBeDefined();
+          expect((error.cause as Error).message.length).toBeGreaterThan(0);
+        }
+      });
     });
 
     describe("createChannelCredentials", () => {


### PR DESCRIPTION
Fixes #191

## Problem
getHostAddress() in DurableTaskAzureManagedClientOptions catches URL parsing errors and re-throws a new Error with a descriptive message, but drops the original error. This makes it difficult to diagnose why a specific endpoint URL is invalid.

## Changes
- Change the catch block to preserve the original error as the cause using { cause: e }
- Consistent with the error wrapping convention used elsewhere in the codebase (e.g., pb-helper.util.ts:434)