### PR TITLE
fix: Make connection string property key lookup case-insensitive

### DIFF
--- a/packages/durabletask-js-azuremanaged/src/connection-string.ts
+++ b/packages/durabletask-js-azuremanaged/src/connection-string.ts
@@ -87,7 +87,7 @@ export class DurableTaskAzureManagedConnectionString {
   }
 
   private getValue(name: string): string | undefined {
-    return this.properties.get(name);
+    return this.properties.get(name.toLowerCase());
   }
 
   private getRequiredValue(name: string): string {
@@ -108,7 +108,7 @@ export class DurableTaskAzureManagedConnectionString {
       if (equalsIndex > 0) {
         const key = pair.substring(0, equalsIndex).trim();
         const value = pair.substring(equalsIndex + 1).trim();
-        properties.set(key, value);
+        properties.set(key.toLowerCase(), value);
       }
     }
 

--- a/packages/durabletask-js-azuremanaged/test/unit/connection-string.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/connection-string.spec.ts
@@ -67,6 +67,46 @@ describe("DurableTaskAzureManagedConnectionString", () => {
         "The connection string must contain a TaskHub property",
       );
     });
+
+    it("should parse connection string with all-lowercase keys", () => {
+      const connectionString = new DurableTaskAzureManagedConnectionString(
+        "endpoint=https://example.com;authentication=ManagedIdentity;taskhub=myTaskHub",
+      );
+
+      expect(connectionString.getEndpoint()).toBe("https://example.com");
+      expect(connectionString.getAuthentication()).toBe("ManagedIdentity");
+      expect(connectionString.getTaskHubName()).toBe("myTaskHub");
+    });
+
+    it("should parse connection string with all-uppercase keys", () => {
+      const connectionString = new DurableTaskAzureManagedConnectionString(
+        "ENDPOINT=https://example.com;AUTHENTICATION=ManagedIdentity;TASKHUB=myTaskHub",
+      );
+
+      expect(connectionString.getEndpoint()).toBe("https://example.com");
+      expect(connectionString.getAuthentication()).toBe("ManagedIdentity");
+      expect(connectionString.getTaskHubName()).toBe("myTaskHub");
+    });
+
+    it("should parse connection string with mixed-case keys", () => {
+      const connectionString = new DurableTaskAzureManagedConnectionString(
+        "endPoint=https://example.com;AUTHENTICATION=ManagedIdentity;taskHub=myTaskHub",
+      );
+
+      expect(connectionString.getEndpoint()).toBe("https://example.com");
+      expect(connectionString.getAuthentication()).toBe("ManagedIdentity");
+      expect(connectionString.getTaskHubName()).toBe("myTaskHub");
+    });
+
+    it("should preserve value casing with case-insensitive keys", () => {
+      const connectionString = new DurableTaskAzureManagedConnectionString(
+        "endpoint=https://MyHost.example.com;authentication=ManagedIdentity;taskhub=MyTaskHub;clientid=My-Client-ID",
+      );
+
+      expect(connectionString.getEndpoint()).toBe("https://MyHost.example.com");
+      expect(connectionString.getTaskHubName()).toBe("MyTaskHub");
+      expect(connectionString.getClientId()).toBe("My-Client-ID");
+    });
   });
 
   describe("getAdditionallyAllowedTenants", () => {
@@ -86,6 +126,16 @@ describe("DurableTaskAzureManagedConnectionString", () => {
       const connectionString = new DurableTaskAzureManagedConnectionString(VALID_CONNECTION_STRING);
 
       expect(connectionString.getAdditionallyAllowedTenants()).toBeUndefined();
+    });
+
+    it("should match property name case-insensitively", () => {
+      const connectionStringWithTenants =
+        VALID_CONNECTION_STRING + ";additionallyallowedtenants=tenant1,tenant2";
+
+      const connectionString = new DurableTaskAzureManagedConnectionString(connectionStringWithTenants);
+      const tenants = connectionString.getAdditionallyAllowedTenants();
+
+      expect(tenants).toEqual(["tenant1", "tenant2"]);
     });
   });
 


### PR DESCRIPTION
Fixes #189

## Problem
DurableTaskAzureManagedConnectionString parses connection string property keys case-sensitively. A connection string with differently-cased keys (e.g., 'endpoint' instead of 'Endpoint') fails validation, violating the Azure SDK convention that connection string property names are case-insensitive.

## Changes
- Normalize keys to lowercase during parsing
- Use lowercase in lookups
- Preserves value casing while making key matching case-insensitive
- Backward-compatible: existing PascalCase connection strings continue to work