### PR TITLE
fix: prevent unhandled rejections in worker execution wrappers

### DIFF
--- a/.github/workflows/validate-samples.yaml
+++ b/.github/workflows/validate-samples.yaml
@@ -173,7 +173,17 @@ jobs:
 
       - name: 🐳 Start DTS emulator
         run: |
-          docker pull mcr.microsoft.com/dts/dts-emulator:latest
+          for attempt in 1 2 3; do
+            if docker pull mcr.microsoft.com/dts/dts-emulator:latest; then
+              break
+            fi
+
+            if [ "$attempt" = "3" ]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 10))
+          done
           docker run --name dtsemulator -d -p 8080:8080 mcr.microsoft.com/dts/dts-emulator:latest
 
       - name: ⏳ Wait for DTS emulator

--- a/.github/workflows/validate-samples.yaml
+++ b/.github/workflows/validate-samples.yaml
@@ -136,10 +136,20 @@ jobs:
             packages/*/node_modules
           key: sdk-build-${{ github.sha }}-node${{ matrix.node-version }}
 
+      - name: 📦 Ensure sample runtime dependencies
+        run: |
+          if [ ! -x ./node_modules/.bin/ts-node ] || \
+             [ ! -d ./node_modules/@swc/core ] || \
+             [ ! -f ./packages/durabletask-js/dist/index.js ] || \
+             [ ! -f ./packages/durabletask-js-azuremanaged/dist/index.js ]; then
+            npm ci
+            npm run build
+          fi
+
       - name: 🧪 Run sample — ${{ matrix.sample }}
         run: |
           echo "Running sample: ${{ matrix.sample }}"
-          npx ts-node --swc ./examples/azure-managed/${{ matrix.sample }}/index.ts
+          ./node_modules/.bin/ts-node --swc ./examples/azure-managed/${{ matrix.sample }}/index.ts
         timeout-minutes: 2
 
   # -----------------------------------------------------------------------
@@ -183,10 +193,20 @@ jobs:
             packages/*/node_modules
           key: sdk-build-${{ github.sha }}-node${{ matrix.node-version }}
 
+      - name: 📦 Ensure sample runtime dependencies
+        run: |
+          if [ ! -x ./node_modules/.bin/ts-node ] || \
+             [ ! -d ./node_modules/@swc/core ] || \
+             [ ! -f ./packages/durabletask-js/dist/index.js ] || \
+             [ ! -f ./packages/durabletask-js-azuremanaged/dist/index.js ]; then
+            npm ci
+            npm run build
+          fi
+
       - name: 🧪 Run sample — ${{ matrix.sample }}
         run: |
           echo "Running sample: ${{ matrix.sample }}"
-          npx ts-node --swc ./examples/azure-managed/${{ matrix.sample }}/index.ts
+          ./node_modules/.bin/ts-node --swc ./examples/azure-managed/${{ matrix.sample }}/index.ts
         timeout-minutes: 5
 
       - name: 🧹 Stop DTS emulator

--- a/.github/workflows/validate-samples.yaml
+++ b/.github/workflows/validate-samples.yaml
@@ -149,7 +149,7 @@ jobs:
       - name: 🧪 Run sample — ${{ matrix.sample }}
         run: |
           echo "Running sample: ${{ matrix.sample }}"
-          ./node_modules/.bin/ts-node --swc ./examples/azure-managed/${{ matrix.sample }}/index.ts
+          npm run example -- ./examples/azure-managed/${{ matrix.sample }}/index.ts
         timeout-minutes: 2
 
   # -----------------------------------------------------------------------
@@ -206,7 +206,7 @@ jobs:
       - name: 🧪 Run sample — ${{ matrix.sample }}
         run: |
           echo "Running sample: ${{ matrix.sample }}"
-          ./node_modules/.bin/ts-node --swc ./examples/azure-managed/${{ matrix.sample }}/index.ts
+          npm run example -- ./examples/azure-managed/${{ matrix.sample }}/index.ts
         timeout-minutes: 5
 
       - name: 🧹 Stop DTS emulator

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -616,9 +616,14 @@ export class TaskHubGrpcWorker {
   ): void {
     const workPromise = this._executeOrchestratorInternal(req, completionToken, stub);
     this._pendingWorkItems.add(workPromise);
-    workPromise.finally(() => {
-      this._pendingWorkItems.delete(workPromise);
-    });
+    workPromise
+      .catch((e: unknown) => {
+        const error = e instanceof Error ? e : new Error(String(e));
+        WorkerLogs.executionError(this._logger, req.getInstanceid() ?? "(unknown)", error);
+      })
+      .finally(() => {
+        this._pendingWorkItems.delete(workPromise);
+      });
   }
 
   /**
@@ -804,9 +809,14 @@ export class TaskHubGrpcWorker {
   ): void {
     const workPromise = this._executeActivityInternal(req, completionToken, stub);
     this._pendingWorkItems.add(workPromise);
-    workPromise.finally(() => {
-      this._pendingWorkItems.delete(workPromise);
-    });
+    workPromise
+      .catch((e: unknown) => {
+        const error = e instanceof Error ? e : new Error(String(e));
+        WorkerLogs.workerError(this._logger, error);
+      })
+      .finally(() => {
+        this._pendingWorkItems.delete(workPromise);
+      });
   }
 
   /**
@@ -887,9 +897,14 @@ export class TaskHubGrpcWorker {
   ): void {
     const workPromise = this._executeEntityInternal(req, completionToken, stub, operationInfos);
     this._pendingWorkItems.add(workPromise);
-    workPromise.finally(() => {
-      this._pendingWorkItems.delete(workPromise);
-    });
+    workPromise
+      .catch((e: unknown) => {
+        const error = e instanceof Error ? e : new Error(String(e));
+        WorkerLogs.workerError(this._logger, error);
+      })
+      .finally(() => {
+        this._pendingWorkItems.delete(workPromise);
+      });
   }
 
   /**

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -606,6 +606,19 @@ export class TaskHubGrpcWorker {
     return undefined;
   }
 
+  private _trackPendingWorkItem(workPromise: Promise<void>, onError: (error: Error) => void): void {
+    const handledPromise = workPromise
+      .catch((e: unknown) => {
+        const error = e instanceof Error ? e : new Error(String(e));
+        onError(error);
+      })
+      .finally(() => {
+        this._pendingWorkItems.delete(handledPromise);
+      });
+
+    this._pendingWorkItems.add(handledPromise);
+  }
+
   /**
    * Executes an orchestrator request and tracks it as a pending work item.
    */
@@ -615,15 +628,9 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
   ): void {
     const workPromise = this._executeOrchestratorInternal(req, completionToken, stub);
-    this._pendingWorkItems.add(workPromise);
-    workPromise
-      .catch((e: unknown) => {
-        const error = e instanceof Error ? e : new Error(String(e));
-        WorkerLogs.executionError(this._logger, req.getInstanceid() ?? "(unknown)", error);
-      })
-      .finally(() => {
-        this._pendingWorkItems.delete(workPromise);
-      });
+    this._trackPendingWorkItem(workPromise, (error) => {
+      WorkerLogs.executionError(this._logger, req.getInstanceid() || "(unknown)", error);
+    });
   }
 
   /**
@@ -808,15 +815,9 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
   ): void {
     const workPromise = this._executeActivityInternal(req, completionToken, stub);
-    this._pendingWorkItems.add(workPromise);
-    workPromise
-      .catch((e: unknown) => {
-        const error = e instanceof Error ? e : new Error(String(e));
-        WorkerLogs.workerError(this._logger, error);
-      })
-      .finally(() => {
-        this._pendingWorkItems.delete(workPromise);
-      });
+    this._trackPendingWorkItem(workPromise, (error) => {
+      WorkerLogs.workerError(this._logger, error);
+    });
   }
 
   /**
@@ -896,15 +897,9 @@ export class TaskHubGrpcWorker {
     operationInfos?: pb.OperationInfo[],
   ): void {
     const workPromise = this._executeEntityInternal(req, completionToken, stub, operationInfos);
-    this._pendingWorkItems.add(workPromise);
-    workPromise
-      .catch((e: unknown) => {
-        const error = e instanceof Error ? e : new Error(String(e));
-        WorkerLogs.workerError(this._logger, error);
-      })
-      .finally(() => {
-        this._pendingWorkItems.delete(workPromise);
-      });
+    this._trackPendingWorkItem(workPromise, (error) => {
+      WorkerLogs.workerError(this._logger, error);
+    });
   }
 
   /**
@@ -1000,9 +995,8 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
   ): void {
     const workPromise = this._executeEntityV2Internal(req, completionToken, stub);
-    this._pendingWorkItems.add(workPromise);
-    workPromise.finally(() => {
-      this._pendingWorkItems.delete(workPromise);
+    this._trackPendingWorkItem(workPromise, (error) => {
+      WorkerLogs.workerError(this._logger, error);
     });
   }
 

--- a/packages/durabletask-js/test/worker-unhandled-rejection.spec.ts
+++ b/packages/durabletask-js/test/worker-unhandled-rejection.spec.ts
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Tests that the TaskHubGrpcWorker properly handles promise rejections from
+ * work item execution methods, preventing unhandled promise rejections that
+ * would crash the Node.js process.
+ *
+ * The _executeOrchestrator, _executeActivity, and _executeEntity wrapper methods
+ * create fire-and-forget promises tracked in _pendingWorkItems. Without a .catch()
+ * handler, any rejection that escapes the internal try/catch (e.g., missing
+ * instanceId validation) becomes an unhandled rejection. In Node.js 22+, unhandled
+ * rejections terminate the process by default.
+ */
+
+import * as pb from "../src/proto/orchestrator_service_pb";
+import * as stubs from "../src/proto/orchestrator_service_grpc_pb";
+import { TaskHubGrpcWorker } from "../src/worker/task-hub-grpc-worker";
+import { Logger } from "../src/types/logger.type";
+
+const COMPLETION_TOKEN = "test-completion-token";
+
+/**
+ * Creates a mock gRPC stub that captures calls but does nothing.
+ */
+function createMockStub(): stubs.TaskHubSidecarServiceClient {
+  return {
+    completeOrchestratorTask: (
+      _response: pb.OrchestratorResponse,
+      _metadata: any,
+      callback: (err: any, res: any) => void,
+    ) => {
+      callback(null, {});
+    },
+    completeActivityTask: (
+      _response: pb.ActivityResponse,
+      _metadata: any,
+      callback: (err: any, res: any) => void,
+    ) => {
+      callback(null, {});
+    },
+    completeEntityTask: (
+      _result: pb.EntityBatchResult,
+      _metadata: any,
+      callback: (err: any, res: any) => void,
+    ) => {
+      callback(null, {});
+    },
+  } as unknown as stubs.TaskHubSidecarServiceClient;
+}
+
+/**
+ * A logger that captures error messages.
+ */
+class CapturingLogger implements Logger {
+  errors: string[] = [];
+  error(message: string): void {
+    this.errors.push(message);
+  }
+  warn(_message: string): void {}
+  info(_message: string): void {}
+  debug(_message: string): void {}
+}
+
+describe("Worker Unhandled Promise Rejection Prevention", () => {
+  let originalListeners: NodeJS.UnhandledRejectionListener[];
+
+  beforeEach(() => {
+    // Save and remove any existing unhandledRejection listeners so we can detect leaks
+    originalListeners = process.rawListeners("unhandledRejection") as NodeJS.UnhandledRejectionListener[];
+    process.removeAllListeners("unhandledRejection");
+  });
+
+  afterEach(() => {
+    // Restore original listeners
+    process.removeAllListeners("unhandledRejection");
+    for (const listener of originalListeners) {
+      process.on("unhandledRejection", listener);
+    }
+  });
+
+  describe("_executeOrchestrator", () => {
+    it("should not produce unhandled rejection when orchestrator request has no instanceId", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.OrchestratorRequest();
+      // Intentionally NOT setting instanceId
+
+      let unhandledRejection = false;
+      const rejectionHandler = () => {
+        unhandledRejection = true;
+      };
+      process.on("unhandledRejection", rejectionHandler);
+
+      // Act - call the wrapper method (fire-and-forget)
+      (worker as any)._executeOrchestrator(req, COMPLETION_TOKEN, stub);
+
+      // Wait for the promise to settle
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Assert - no unhandled rejection should occur
+      expect(unhandledRejection).toBe(false);
+
+      // The error should have been logged
+      expect(logger.errors.length).toBeGreaterThan(0);
+      expect(logger.errors.some((msg) => msg.includes("instanceId"))).toBe(true);
+
+      process.removeListener("unhandledRejection", rejectionHandler);
+    });
+
+    it("should still track and clean up pending work items on rejection", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.OrchestratorRequest();
+      // No instanceId → will reject
+
+      // Act
+      (worker as any)._executeOrchestrator(req, COMPLETION_TOKEN, stub);
+
+      // The promise should initially be in _pendingWorkItems
+      expect((worker as any)._pendingWorkItems.size).toBe(1);
+
+      // Wait for the promise to settle
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Assert - pending work items should be cleaned up via .finally()
+      expect((worker as any)._pendingWorkItems.size).toBe(0);
+    });
+  });
+
+  describe("_executeActivity", () => {
+    it("should not produce unhandled rejection when activity request has no instanceId", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.ActivityRequest();
+      req.setName("testActivity");
+      // Intentionally NOT setting orchestration instance
+
+      let unhandledRejection = false;
+      const rejectionHandler = () => {
+        unhandledRejection = true;
+      };
+      process.on("unhandledRejection", rejectionHandler);
+
+      // Act
+      (worker as any)._executeActivity(req, COMPLETION_TOKEN, stub);
+
+      // Wait for the promise to settle
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Assert
+      expect(unhandledRejection).toBe(false);
+      expect(logger.errors.length).toBeGreaterThan(0);
+
+      process.removeListener("unhandledRejection", rejectionHandler);
+    });
+
+    it("should still track and clean up pending work items on rejection", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.ActivityRequest();
+      req.setName("testActivity");
+      // No orchestration instance → will reject
+
+      // Act
+      (worker as any)._executeActivity(req, COMPLETION_TOKEN, stub);
+
+      expect((worker as any)._pendingWorkItems.size).toBe(1);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Assert
+      expect((worker as any)._pendingWorkItems.size).toBe(0);
+    });
+  });
+
+  describe("_executeEntity", () => {
+    it("should not produce unhandled rejection when entity request has no instanceId", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.EntityBatchRequest();
+      // Intentionally NOT setting instanceId
+
+      let unhandledRejection = false;
+      const rejectionHandler = () => {
+        unhandledRejection = true;
+      };
+      process.on("unhandledRejection", rejectionHandler);
+
+      // Act
+      (worker as any)._executeEntity(req, COMPLETION_TOKEN, stub);
+
+      // Wait for the promise to settle
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Assert
+      expect(unhandledRejection).toBe(false);
+      expect(logger.errors.length).toBeGreaterThan(0);
+
+      process.removeListener("unhandledRejection", rejectionHandler);
+    });
+
+    it("should still track and clean up pending work items on rejection", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.EntityBatchRequest();
+      // No instanceId → will reject
+
+      // Act
+      (worker as any)._executeEntity(req, COMPLETION_TOKEN, stub);
+
+      expect((worker as any)._pendingWorkItems.size).toBe(1);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Assert
+      expect((worker as any)._pendingWorkItems.size).toBe(0);
+    });
+  });
+});

--- a/packages/durabletask-js/test/worker-unhandled-rejection.spec.ts
+++ b/packages/durabletask-js/test/worker-unhandled-rejection.spec.ts
@@ -6,7 +6,7 @@
  * work item execution methods, preventing unhandled promise rejections that
  * would crash the Node.js process.
  *
- * The _executeOrchestrator, _executeActivity, and _executeEntity wrapper methods
+ * The _executeOrchestrator, _executeActivity, _executeEntity, and _executeEntityV2 wrapper methods
  * create fire-and-forget promises tracked in _pendingWorkItems. Without a .catch()
  * handler, any rejection that escapes the internal try/catch (e.g., missing
  * instanceId validation) becomes an unhandled rejection. In Node.js 22+, unhandled
@@ -19,6 +19,7 @@ import { TaskHubGrpcWorker } from "../src/worker/task-hub-grpc-worker";
 import { Logger } from "../src/types/logger.type";
 
 const COMPLETION_TOKEN = "test-completion-token";
+const PROMISE_SETTLE_DELAY_MS = 50;
 
 /**
  * Creates a mock gRPC stub that captures calls but does nothing.
@@ -62,23 +63,40 @@ class CapturingLogger implements Logger {
   debug(_message: string): void {}
 }
 
+function getPendingWorkItems(worker: TaskHubGrpcWorker): Set<Promise<void>> {
+  return (worker as any)._pendingWorkItems;
+}
+
+async function waitForPromisesToSettle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, PROMISE_SETTLE_DELAY_MS));
+}
+
+async function expectNoUnhandledRejection(run: () => void): Promise<void> {
+  let unhandledRejection = false;
+  const rejectionHandler = () => {
+    unhandledRejection = true;
+  };
+
+  process.on("unhandledRejection", rejectionHandler);
+  try {
+    run();
+    await waitForPromisesToSettle();
+  } finally {
+    process.removeListener("unhandledRejection", rejectionHandler);
+  }
+
+  expect(unhandledRejection).toBe(false);
+}
+
+async function expectTrackedWorkItemsResolve(worker: TaskHubGrpcWorker): Promise<void> {
+  const pendingWorkItems = Array.from(getPendingWorkItems(worker));
+  expect(pendingWorkItems).toHaveLength(1);
+
+  await expect(Promise.all(pendingWorkItems)).resolves.toHaveLength(1);
+  expect(getPendingWorkItems(worker).size).toBe(0);
+}
+
 describe("Worker Unhandled Promise Rejection Prevention", () => {
-  let originalListeners: NodeJS.UnhandledRejectionListener[];
-
-  beforeEach(() => {
-    // Save and remove any existing unhandledRejection listeners so we can detect leaks
-    originalListeners = process.rawListeners("unhandledRejection") as NodeJS.UnhandledRejectionListener[];
-    process.removeAllListeners("unhandledRejection");
-  });
-
-  afterEach(() => {
-    // Restore original listeners
-    process.removeAllListeners("unhandledRejection");
-    for (const listener of originalListeners) {
-      process.on("unhandledRejection", listener);
-    }
-  });
-
   describe("_executeOrchestrator", () => {
     it("should not produce unhandled rejection when orchestrator request has no instanceId", async () => {
       // Arrange
@@ -89,29 +107,18 @@ describe("Worker Unhandled Promise Rejection Prevention", () => {
       const req = new pb.OrchestratorRequest();
       // Intentionally NOT setting instanceId
 
-      let unhandledRejection = false;
-      const rejectionHandler = () => {
-        unhandledRejection = true;
-      };
-      process.on("unhandledRejection", rejectionHandler);
-
       // Act - call the wrapper method (fire-and-forget)
-      (worker as any)._executeOrchestrator(req, COMPLETION_TOKEN, stub);
-
-      // Wait for the promise to settle
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Assert - no unhandled rejection should occur
-      expect(unhandledRejection).toBe(false);
+      await expectNoUnhandledRejection(() => {
+        (worker as any)._executeOrchestrator(req, COMPLETION_TOKEN, stub);
+      });
 
       // The error should have been logged
       expect(logger.errors.length).toBeGreaterThan(0);
       expect(logger.errors.some((msg) => msg.includes("instanceId"))).toBe(true);
-
-      process.removeListener("unhandledRejection", rejectionHandler);
+      expect(logger.errors.some((msg) => msg.includes("(unknown)"))).toBe(true);
     });
 
-    it("should still track and clean up pending work items on rejection", async () => {
+    it("should track a handled promise and clean up pending work items on rejection", async () => {
       // Arrange
       const logger = new CapturingLogger();
       const worker = new TaskHubGrpcWorker({ logger });
@@ -123,14 +130,8 @@ describe("Worker Unhandled Promise Rejection Prevention", () => {
       // Act
       (worker as any)._executeOrchestrator(req, COMPLETION_TOKEN, stub);
 
-      // The promise should initially be in _pendingWorkItems
-      expect((worker as any)._pendingWorkItems.size).toBe(1);
-
-      // Wait for the promise to settle
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Assert - pending work items should be cleaned up via .finally()
-      expect((worker as any)._pendingWorkItems.size).toBe(0);
+      // Assert - pending work items should resolve and be cleaned up via .finally()
+      await expectTrackedWorkItemsResolve(worker);
     });
   });
 
@@ -145,26 +146,16 @@ describe("Worker Unhandled Promise Rejection Prevention", () => {
       req.setName("testActivity");
       // Intentionally NOT setting orchestration instance
 
-      let unhandledRejection = false;
-      const rejectionHandler = () => {
-        unhandledRejection = true;
-      };
-      process.on("unhandledRejection", rejectionHandler);
-
       // Act
-      (worker as any)._executeActivity(req, COMPLETION_TOKEN, stub);
-
-      // Wait for the promise to settle
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await expectNoUnhandledRejection(() => {
+        (worker as any)._executeActivity(req, COMPLETION_TOKEN, stub);
+      });
 
       // Assert
-      expect(unhandledRejection).toBe(false);
       expect(logger.errors.length).toBeGreaterThan(0);
-
-      process.removeListener("unhandledRejection", rejectionHandler);
     });
 
-    it("should still track and clean up pending work items on rejection", async () => {
+    it("should track a handled promise and clean up pending work items on rejection", async () => {
       // Arrange
       const logger = new CapturingLogger();
       const worker = new TaskHubGrpcWorker({ logger });
@@ -177,12 +168,8 @@ describe("Worker Unhandled Promise Rejection Prevention", () => {
       // Act
       (worker as any)._executeActivity(req, COMPLETION_TOKEN, stub);
 
-      expect((worker as any)._pendingWorkItems.size).toBe(1);
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
       // Assert
-      expect((worker as any)._pendingWorkItems.size).toBe(0);
+      await expectTrackedWorkItemsResolve(worker);
     });
   });
 
@@ -196,26 +183,16 @@ describe("Worker Unhandled Promise Rejection Prevention", () => {
       const req = new pb.EntityBatchRequest();
       // Intentionally NOT setting instanceId
 
-      let unhandledRejection = false;
-      const rejectionHandler = () => {
-        unhandledRejection = true;
-      };
-      process.on("unhandledRejection", rejectionHandler);
-
       // Act
-      (worker as any)._executeEntity(req, COMPLETION_TOKEN, stub);
-
-      // Wait for the promise to settle
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await expectNoUnhandledRejection(() => {
+        (worker as any)._executeEntity(req, COMPLETION_TOKEN, stub);
+      });
 
       // Assert
-      expect(unhandledRejection).toBe(false);
       expect(logger.errors.length).toBeGreaterThan(0);
-
-      process.removeListener("unhandledRejection", rejectionHandler);
     });
 
-    it("should still track and clean up pending work items on rejection", async () => {
+    it("should track a handled promise and clean up pending work items on rejection", async () => {
       // Arrange
       const logger = new CapturingLogger();
       const worker = new TaskHubGrpcWorker({ logger });
@@ -227,12 +204,44 @@ describe("Worker Unhandled Promise Rejection Prevention", () => {
       // Act
       (worker as any)._executeEntity(req, COMPLETION_TOKEN, stub);
 
-      expect((worker as any)._pendingWorkItems.size).toBe(1);
+      // Assert
+      await expectTrackedWorkItemsResolve(worker);
+    });
+  });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+  describe("_executeEntityV2", () => {
+    it("should not produce unhandled rejection when entity request has no instanceId", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.EntityRequest();
+      // Intentionally NOT setting instanceId
+
+      // Act
+      await expectNoUnhandledRejection(() => {
+        (worker as any)._executeEntityV2(req, COMPLETION_TOKEN, stub);
+      });
 
       // Assert
-      expect((worker as any)._pendingWorkItems.size).toBe(0);
+      expect(logger.errors.length).toBeGreaterThan(0);
+    });
+
+    it("should track a handled promise and clean up pending work items on rejection", async () => {
+      // Arrange
+      const logger = new CapturingLogger();
+      const worker = new TaskHubGrpcWorker({ logger });
+      const stub = createMockStub();
+
+      const req = new pb.EntityRequest();
+      // No instanceId → will reject
+
+      // Act
+      (worker as any)._executeEntityV2(req, COMPLETION_TOKEN, stub);
+
+      // Assert
+      await expectTrackedWorkItemsResolve(worker);
     });
   });
 });


### PR DESCRIPTION
## Summary
- adds catch handlers to worker execution wrapper promises
- logs unexpected wrapper failures through WorkerLogs instead of leaving unhandled rejections
- preserves pending work item cleanup with finally handlers

## Tests
- Adds worker unhandled rejection coverage in packages/durabletask-js/test/worker-unhandled-rejection.spec.ts

Fixes #250