### PR TITLE
Improve withTimeout validation and remove dead sleepWithAbort

### DIFF
--- a/packages/durabletask-js/src/utils/backoff.util.ts
+++ b/packages/durabletask-js/src/utils/backoff.util.ts
@@ -172,35 +172,6 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Creates a promise that resolves after the specified delay,
- * but can be cancelled via an AbortSignal.
- *
- * @param ms Delay in milliseconds.
- * @param signal Optional AbortSignal to cancel the sleep.
- * @returns Promise that resolves after the delay or rejects if aborted.
- */
-export function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new Error("Sleep aborted"));
-      return;
-    }
-
-    const onAbort = () => {
-      clearTimeout(timeoutId);
-      reject(new Error("Sleep aborted"));
-    };
-
-    const timeoutId = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
-/**
  * Waits for a promise to resolve with a timeout.
  *
  * @param promise The promise to wait for.
@@ -213,6 +184,10 @@ export async function withTimeout<T>(
   timeoutMs: number,
   timeoutMessage = "Operation timed out",
 ): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+    throw new RangeError(`timeoutMs must be a finite number >= 0, got ${timeoutMs}`);
+  }
+
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   const timeoutPromise = new Promise<never>((_, reject) => {

--- a/packages/durabletask-js/test/backoff.spec.ts
+++ b/packages/durabletask-js/test/backoff.spec.ts
@@ -192,4 +192,25 @@ describe("withTimeout", () => {
     const failingPromise = Promise.reject(new Error("Promise failed"));
     await expect(withTimeout(failingPromise, 1000)).rejects.toThrow("Promise failed");
   });
+
+  it("should reject NaN timeoutMs with RangeError", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), NaN)).rejects.toThrow(RangeError);
+  });
+
+  it("should reject Infinity timeoutMs with RangeError", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), Infinity)).rejects.toThrow(RangeError);
+  });
+
+  it("should reject -Infinity timeoutMs with RangeError", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), -Infinity)).rejects.toThrow(RangeError);
+  });
+
+  it("should reject negative timeoutMs with RangeError", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), -1)).rejects.toThrow(RangeError);
+  });
+
+  it("should accept zero timeoutMs", async () => {
+    // Zero timeout means the timeout fires immediately, but a resolved promise wins the race
+    await expect(withTimeout(Promise.resolve("ok"), 0)).resolves.toBe("ok");
+  });
 });


### PR DESCRIPTION
## Summary
- validates withTimeout timeout values before scheduling timers
- removes the unused sleepWithAbort export
- adds unit coverage for invalid timeout inputs

## Tests
- Added/updated backoff unit tests in packages/durabletask-js/test/backoff.spec.ts

Fixes #251