### PR TITLE
fix: use epoch fallback for missing orchestration timestamps

### DIFF
--- a/packages/durabletask-js/src/orchestration/index.ts
+++ b/packages/durabletask-js/src/orchestration/index.ts
@@ -27,19 +27,11 @@ export function newOrchestrationState(
     );
   }
 
-  // Convert Timestamp seconds and nanos to Date.
-  // Default to epoch (new Date(0)) when timestamps are missing, consistent with
-  // _createOrchestrationStateFromProto in client.ts.
   const tsCreated = state?.getCreatedtimestamp();
   const tsUpdated = state?.getLastupdatedtimestamp();
 
-  const createdAt = tsCreated
-    ? new Date(tsCreated.getSeconds() * 1000 + tsCreated.getNanos() / 1000000)
-    : new Date(0);
-
-  const lastUpdatedAt = tsUpdated
-    ? new Date(tsUpdated.getSeconds() * 1000 + tsUpdated.getNanos() / 1000000)
-    : new Date(0);
+  const createdAt = tsCreated ? tsCreated.toDate() : new Date(0);
+  const lastUpdatedAt = tsUpdated ? tsUpdated.toDate() : new Date(0);
 
   const tags = mapToRecord(state?.getTagsMap());
 

--- a/packages/durabletask-js/src/orchestration/index.ts
+++ b/packages/durabletask-js/src/orchestration/index.ts
@@ -27,20 +27,19 @@ export function newOrchestrationState(
     );
   }
 
-  // Convert Timestamp seconds and nanos to Date
+  // Convert Timestamp seconds and nanos to Date.
+  // Default to epoch (new Date(0)) when timestamps are missing, consistent with
+  // _createOrchestrationStateFromProto in client.ts.
   const tsCreated = state?.getCreatedtimestamp();
   const tsUpdated = state?.getLastupdatedtimestamp();
 
-  let tsCreatedParsed = new Date();
-  let tsUpdatedParsed = new Date();
+  const createdAt = tsCreated
+    ? new Date(tsCreated.getSeconds() * 1000 + tsCreated.getNanos() / 1000000)
+    : new Date(0);
 
-  if (tsCreated) {
-    tsCreatedParsed = new Date(tsCreated.getSeconds() * 1000 + tsCreated.getNanos() / 1000000);
-  }
-
-  if (tsUpdated) {
-    tsUpdatedParsed = new Date(tsUpdated.getSeconds() * 1000 + tsUpdated.getNanos() / 1000000);
-  }
+  const lastUpdatedAt = tsUpdated
+    ? new Date(tsUpdated.getSeconds() * 1000 + tsUpdated.getNanos() / 1000000)
+    : new Date(0);
 
   const tags = mapToRecord(state?.getTagsMap());
 
@@ -48,8 +47,8 @@ export function newOrchestrationState(
     instanceId,
     state?.getName() ?? "",
     fromProtobuf(state?.getOrchestrationstatus() ?? 0),
-    new Date(tsCreatedParsed),
-    new Date(tsUpdatedParsed),
+    createdAt,
+    lastUpdatedAt,
     state?.getInput()?.getValue(),
     state?.getOutput()?.getValue(),
     state?.getCustomstatus()?.getValue(),

--- a/packages/durabletask-js/test/new-orchestration-state.spec.ts
+++ b/packages/durabletask-js/test/new-orchestration-state.spec.ts
@@ -202,6 +202,45 @@ describe("newOrchestrationState", () => {
     );
   });
 
+  it("should default to epoch when timestamps are missing from proto response", () => {
+    const state = new pb.OrchestrationState();
+    state.setName("TestOrchestrator");
+    state.setOrchestrationstatus(pb.OrchestrationStatus.ORCHESTRATION_STATUS_RUNNING);
+    // Intentionally NOT setting createdtimestamp or lastupdatedtimestamp
+
+    const res = new pb.GetInstanceResponse();
+    res.setExists(true);
+    res.setOrchestrationstate(state);
+
+    const result = newOrchestrationState("test-id", res);
+
+    expect(result).toBeDefined();
+    expect(result!.createdAt).toEqual(new Date(0));
+    expect(result!.lastUpdatedAt).toEqual(new Date(0));
+  });
+
+  it("should preserve valid timestamps from proto response", () => {
+    const state = new pb.OrchestrationState();
+    state.setName("TestOrchestrator");
+    state.setOrchestrationstatus(pb.OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+
+    const specificDate = new Date("2025-06-15T12:00:00Z");
+    const ts = new Timestamp();
+    ts.fromDate(specificDate);
+    state.setCreatedtimestamp(ts);
+    state.setLastupdatedtimestamp(ts);
+
+    const res = new pb.GetInstanceResponse();
+    res.setExists(true);
+    res.setOrchestrationstate(state);
+
+    const result = newOrchestrationState("test-id", res);
+
+    expect(result).toBeDefined();
+    expect(result!.createdAt.getTime()).toBe(specificDate.getTime());
+    expect(result!.lastUpdatedAt.getTime()).toBe(specificDate.getTime());
+  });
+
   it("should handle failure details without stack trace", () => {
     const failureDetails = new pb.TaskFailureDetails();
     failureDetails.setErrormessage("error without stack");


### PR DESCRIPTION
## Summary
- Makes missing orchestration timestamps default consistently instead of using the current time.
- Opens the existing fix branch for issue #246

Fixes #246