### PR TITLE
fix: use epoch fallback for entity lastModifiedTime

### DIFF
--- a/packages/durabletask-js/src/client/client.ts
+++ b/packages/durabletask-js/src/client/client.ts
@@ -1205,7 +1205,7 @@ export class TaskHubGrpcClient {
     const instanceIdStr = protoMetadata.getInstanceid();
     const entityId = EntityInstanceId.fromString(instanceIdStr);
 
-    const lastModifiedTime = protoMetadata.getLastmodifiedtime()?.toDate() ?? new Date();
+    const lastModifiedTime = protoMetadata.getLastmodifiedtime()?.toDate() ?? new Date(0);
     const backlogQueueSize = protoMetadata.getBacklogqueuesize();
     const lockedBy = protoMetadata.getLockedby()?.getValue();
     const serializedState = protoMetadata.getSerializedstate()?.getValue();

--- a/packages/durabletask-js/test/entity-client.spec.ts
+++ b/packages/durabletask-js/test/entity-client.spec.ts
@@ -287,6 +287,39 @@ describe("Entity Client Proto Conversion", () => {
       expect(metadata.getSerializedstate()).toBeUndefined();
     });
 
+    it("should default lastModifiedTime to epoch when missing from proto", () => {
+      // Arrange - proto metadata without lastModifiedTime set
+      const metadata = new pb.EntityMetadata();
+      metadata.setInstanceid("@counter@test");
+      metadata.setBacklogqueuesize(0);
+      // No lastModifiedTime set
+
+      // Act - replicate the same logic as convertEntityMetadata
+      const lastModifiedTime = metadata.getLastmodifiedtime()?.toDate() ?? new Date(0);
+
+      // Assert - should default to epoch (not current time) for consistency
+      // with OrchestrationState's createdAt/lastUpdatedAt defaults
+      expect(lastModifiedTime.getTime()).toBe(0);
+    });
+
+    it("should use actual timestamp when lastModifiedTime is present in proto", () => {
+      // Arrange
+      const metadata = new pb.EntityMetadata();
+      metadata.setInstanceid("@counter@test");
+      metadata.setBacklogqueuesize(0);
+
+      const expectedDate = new Date("2026-03-15T10:30:00Z");
+      const ts = new Timestamp();
+      ts.fromDate(expectedDate);
+      metadata.setLastmodifiedtime(ts);
+
+      // Act - replicate the same logic as convertEntityMetadata
+      const lastModifiedTime = metadata.getLastmodifiedtime()?.toDate() ?? new Date(0);
+
+      // Assert - should use the actual timestamp
+      expect(lastModifiedTime.toISOString()).toBe(expectedDate.toISOString());
+    });
+
     it("should gracefully handle invalid JSON in serialized state", () => {
       // Arrange - simulate what convertEntityMetadata does
       const metadata = new pb.EntityMetadata();

--- a/packages/durabletask-js/test/entity-client.spec.ts
+++ b/packages/durabletask-js/test/entity-client.spec.ts
@@ -3,9 +3,20 @@
 
 import { EntityInstanceId } from "../src/entities/entity-instance-id";
 import { EntityQuery } from "../src/entities/entity-query";
+import { EntityMetadata } from "../src/entities/entity-metadata";
+import { TaskHubGrpcClient } from "../src/client/client";
 import * as pb from "../src/proto/orchestrator_service_pb";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { StringValue, Int32Value } from "google-protobuf/google/protobuf/wrappers_pb";
+
+type EntityMetadataConverter = {
+  convertEntityMetadata<T>(protoMetadata: pb.EntityMetadata, includeState: boolean): EntityMetadata<T>;
+};
+
+function convertEntityMetadata<T>(metadata: pb.EntityMetadata, includeState = false): EntityMetadata<T> {
+  const client = new TaskHubGrpcClient({ hostAddress: "localhost:4001" });
+  return (client as unknown as EntityMetadataConverter).convertEntityMetadata<T>(metadata, includeState);
+}
 
 // Note: These are unit tests for the entity client methods.
 // They test the proto request/response conversion logic.
@@ -294,12 +305,12 @@ describe("Entity Client Proto Conversion", () => {
       metadata.setBacklogqueuesize(0);
       // No lastModifiedTime set
 
-      // Act - replicate the same logic as convertEntityMetadata
-      const lastModifiedTime = metadata.getLastmodifiedtime()?.toDate() ?? new Date(0);
+      // Act
+      const result = convertEntityMetadata(metadata);
 
       // Assert - should default to epoch (not current time) for consistency
       // with OrchestrationState's createdAt/lastUpdatedAt defaults
-      expect(lastModifiedTime.getTime()).toBe(0);
+      expect(result.lastModifiedTime.getTime()).toBe(0);
     });
 
     it("should use actual timestamp when lastModifiedTime is present in proto", () => {
@@ -313,11 +324,11 @@ describe("Entity Client Proto Conversion", () => {
       ts.fromDate(expectedDate);
       metadata.setLastmodifiedtime(ts);
 
-      // Act - replicate the same logic as convertEntityMetadata
-      const lastModifiedTime = metadata.getLastmodifiedtime()?.toDate() ?? new Date(0);
+      // Act
+      const result = convertEntityMetadata(metadata);
 
       // Assert - should use the actual timestamp
-      expect(lastModifiedTime.toISOString()).toBe(expectedDate.toISOString());
+      expect(result.lastModifiedTime.toISOString()).toBe(expectedDate.toISOString());
     });
 
     it("should gracefully handle invalid JSON in serialized state", () => {


### PR DESCRIPTION
## Summary
- Uses an epoch timestamp fallback for missing entity lastModifiedTime values.
- Opens the existing fix branch for issue #240

Fixes #240