### PR TITLE
fix: preserve continue-as-new carryover event ordering

### DIFF
--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -493,14 +493,15 @@ export class InMemoryOrchestrationBackend {
       instance.failureDetails = undefined;
       instance.status = pb.OrchestrationStatus.ORCHESTRATION_STATUS_PENDING;
 
-      // Add carryover events
-      instance.pendingEvents = [...carryoverEvents];
-
-      // Add new execution started events
+      // Add new execution started events first, then carryover events.
+      // This matches the real sidecar behavior where OrchestratorStarted and
+      // ExecutionStarted always precede any carryover events (buffered external
+      // events from the previous iteration). OrchestratorStarted must come first
+      // because it sets currentUtcDateTime, and ExecutionStarted must come before
+      // carryover events because it initializes the orchestrator generator.
       const orchestratorStarted = pbh.newOrchestratorStartedEvent(new Date());
       const executionStarted = pbh.newExecutionStartedEvent(instance.name, instance.instanceId, newInput);
-      instance.pendingEvents.push(orchestratorStarted);
-      instance.pendingEvents.push(executionStarted);
+      instance.pendingEvents = [orchestratorStarted, executionStarted, ...carryoverEvents];
 
       this.enqueueOrchestration(instance.instanceId);
     }

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -13,6 +13,7 @@ import {
   Task,
   TOrchestrator,
 } from "../src";
+import * as pb from "../src/proto/orchestrator_service_pb";
 
 describe("In-Memory Backend", () => {
   let backend: InMemoryOrchestrationBackend;
@@ -292,8 +293,9 @@ describe("In-Memory Backend", () => {
 
     const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext, input: { iteration: number }): any {
       if (input.iteration === 1) {
-        // Wait for a timer to give the test time to raise an event
-        yield ctx.createTimer(0);
+        // Wait for a separate event so the test can deterministically enqueue
+        // the carryover event before continue-as-new runs.
+        yield ctx.waitForExternalEvent("continue");
         // Do NOT consume the "carry-me" event — it should be carried over
         ctx.continueAsNew({ iteration: 2 }, true); // saveEvents = true
       } else {
@@ -308,11 +310,12 @@ describe("In-Memory Backend", () => {
 
     const id = await client.scheduleNewOrchestration(orchestrator, { iteration: 1 });
 
-    // Wait for the orchestration to start running (timer is created)
+    // Wait for the orchestration to start and block on the "continue" event.
     await client.waitForOrchestrationStart(id, false, 5);
 
     // Raise an external event that the first iteration won't consume
     await client.raiseOrchestrationEvent(id, "carry-me", "carried-over-payload");
+    await client.raiseOrchestrationEvent(id, "continue");
 
     // The orchestration should continue-as-new and then complete in iteration 2
     const state = await client.waitForOrchestrationCompletion(id, true, 10);
@@ -320,6 +323,16 @@ describe("In-Memory Backend", () => {
     expect(state).toBeDefined();
     expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
     expect(state?.serializedOutput).toEqual(JSON.stringify("carried-over-payload"));
+
+    const history = backend.getInstance(id)?.history ?? [];
+    const iterationStart = history.findIndex(
+      (event) => event.getEventtypeCase() === pb.HistoryEvent.EventtypeCase.ORCHESTRATORSTARTED,
+    );
+    expect(iterationStart).toBeGreaterThanOrEqual(0);
+    expect(history[iterationStart]?.getEventtypeCase()).toBe(pb.HistoryEvent.EventtypeCase.ORCHESTRATORSTARTED);
+    expect(history[iterationStart + 1]?.getEventtypeCase()).toBe(pb.HistoryEvent.EventtypeCase.EXECUTIONSTARTED);
+    expect(history[iterationStart + 2]?.getEventtypeCase()).toBe(pb.HistoryEvent.EventtypeCase.EVENTRAISED);
+    expect(history[iterationStart + 2]?.getEventraised()?.getName()).toBe("carry-me");
   });
 
   it("should clear customStatus after continue-as-new", async () => {

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -279,6 +279,49 @@ describe("In-Memory Backend", () => {
     expect(state?.serializedOutput).toEqual(JSON.stringify(5));
   });
 
+  it("should deliver carryover events after ExecutionStarted during continue-as-new", async () => {
+    // This test verifies that carryover events (saved external events) are
+    // delivered AFTER OrchestratorStarted and ExecutionStarted when
+    // continuing-as-new with saveEvents=true. This matches the real sidecar
+    // behavior. If carryover events were delivered before ExecutionStarted,
+    // the orchestrator generator would not be initialized yet.
+    //
+    // Scenario: An external event is raised on the orchestration. The first
+    // iteration does NOT consume it. It continues-as-new with saveEvents=true.
+    // The second iteration should receive the carried-over event.
+
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext, input: { iteration: number }): any {
+      if (input.iteration === 1) {
+        // Wait for a timer to give the test time to raise an event
+        yield ctx.createTimer(0);
+        // Do NOT consume the "carry-me" event — it should be carried over
+        ctx.continueAsNew({ iteration: 2 }, true); // saveEvents = true
+      } else {
+        // Second iteration: the carried-over event should be available
+        const val = yield ctx.waitForExternalEvent("carry-me");
+        return val;
+      }
+    };
+
+    worker.addOrchestrator(orchestrator);
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator, { iteration: 1 });
+
+    // Wait for the orchestration to start running (timer is created)
+    await client.waitForOrchestrationStart(id, false, 5);
+
+    // Raise an external event that the first iteration won't consume
+    await client.raiseOrchestrationEvent(id, "carry-me", "carried-over-payload");
+
+    // The orchestration should continue-as-new and then complete in iteration 2
+    const state = await client.waitForOrchestrationCompletion(id, true, 10);
+
+    expect(state).toBeDefined();
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toEqual(JSON.stringify("carried-over-payload"));
+  });
+
   it("should clear customStatus after continue-as-new", async () => {
     const orchestrator: TOrchestrator = async (ctx: OrchestrationContext, input: number) => {
       if (input === 1) {


### PR DESCRIPTION
## Summary
- Places continue-as-new carryover events after orchestration start events in the in-memory backend.
- Opens the existing fix branch for issue #234

Fixes #234