### PR TITLE
fix: treat empty entity operation input as no input

### DIFF
--- a/packages/durabletask-js/src/worker/entity-executor.ts
+++ b/packages/durabletask-js/src/worker/entity-executor.ts
@@ -11,6 +11,7 @@ import * as pb from "../proto/orchestrator_service_pb";
 import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { randomUUID } from "crypto";
+import { parseJsonField } from "../utils/pb-helper.util";
 
 /**
  * Internal type representing actions collected during entity execution.
@@ -356,7 +357,11 @@ export class TaskEntityShim {
 
     try {
       const inputValue = opRequest.getInput();
-      const input = inputValue ? JSON.parse(inputValue.getValue()) : undefined;
+      // Use the shared parseJsonField helper so an empty StringValue is treated as
+      // "no input" (returns undefined) instead of crashing on JSON.parse(""). A
+      // StringValue object is always truthy, so the previous `inputValue ? ...`
+      // guard did not protect against an empty wrapped string.
+      const input = parseJsonField(inputValue);
 
       // Set operation details
       this.operationShim.setNameAndInput(opRequest.getOperation(), input);

--- a/packages/durabletask-js/test/entity-executor.spec.ts
+++ b/packages/durabletask-js/test/entity-executor.spec.ts
@@ -69,6 +69,17 @@ class CounterEntity extends TaskEntity<{ count: number }> {
   }
 }
 
+// Entity used to assert how operation input is delivered to the dispatched method.
+class InputCaptureEntity extends TaskEntity<{ calls: number }> {
+  capture(input?: unknown): { hadInput: boolean; value: unknown } {
+    return { hadInput: input !== undefined, value: input ?? null };
+  }
+
+  protected initializeState(): { calls: number } {
+    return { calls: 0 };
+  }
+}
+
 describe("TaskEntityShim", () => {
   const entityId = new EntityInstanceId("counter", "test");
 
@@ -612,6 +623,81 @@ describe("TaskEntityShim", () => {
       // Second operation succeeds, state should be rolled back to 10
       expect(result.getResultsList()[1].hasSuccess()).toBe(true);
       expect(JSON.parse(result.getResultsList()[1].getSuccess()!.getResult()!.getValue())).toBe(10);
+    });
+  });
+
+  describe("empty operation input", () => {
+    it("should treat an empty StringValue input as no input instead of throwing SyntaxError", async () => {
+      const entity = new CounterEntity();
+      const shim = new TaskEntityShim(entity, entityId);
+
+      // Manually build a request whose operation input is an empty StringValue.
+      // A StringValue wrapping "" is a truthy object, so the previous inline
+      // `inputValue ? JSON.parse(inputValue.getValue()) : undefined` guard used to
+      // call JSON.parse("") and throw "Unexpected end of JSON input", failing the
+      // operation and rolling it back instead of treating it as no input.
+      const request = new pb.EntityBatchRequest();
+      request.setInstanceid(entityId.toString());
+
+      const stateValue = new StringValue();
+      stateValue.setValue(JSON.stringify({ count: 7 }));
+      request.setEntitystate(stateValue);
+
+      const opRequest = new pb.OperationRequest();
+      opRequest.setOperation("get");
+      opRequest.setInput(new StringValue()); // empty StringValue, getValue() === ""
+      request.addOperations(opRequest);
+
+      const result = await shim.executeAsync(request);
+
+      const opResult = result.getResultsList()[0];
+      expect(opResult.hasFailure()).toBe(false);
+      expect(opResult.hasSuccess()).toBe(true);
+      expect(JSON.parse(opResult.getSuccess()!.getResult()!.getValue())).toBe(7);
+    });
+
+    it("should dispatch the operation with no input when the StringValue is empty", async () => {
+      const entity = new InputCaptureEntity();
+      const shim = new TaskEntityShim(entity, entityId);
+
+      const request = new pb.EntityBatchRequest();
+      request.setInstanceid(entityId.toString());
+
+      const opRequest = new pb.OperationRequest();
+      opRequest.setOperation("capture");
+      opRequest.setInput(new StringValue()); // empty StringValue
+      request.addOperations(opRequest);
+
+      const result = await shim.executeAsync(request);
+
+      const opResult = result.getResultsList()[0];
+      expect(opResult.hasSuccess()).toBe(true);
+      const captured = JSON.parse(opResult.getSuccess()!.getResult()!.getValue());
+      expect(captured).toEqual({ hadInput: false, value: null });
+    });
+
+    it("should still deliver a genuine empty-string JSON value when explicitly provided", async () => {
+      // Sanity check: a StringValue holding the JSON text '""' is a real empty
+      // string input and must be delivered as "" (not dropped as "no input").
+      const entity = new InputCaptureEntity();
+      const shim = new TaskEntityShim(entity, entityId);
+
+      const request = new pb.EntityBatchRequest();
+      request.setInstanceid(entityId.toString());
+
+      const opRequest = new pb.OperationRequest();
+      opRequest.setOperation("capture");
+      const inputValue = new StringValue();
+      inputValue.setValue(JSON.stringify("")); // the two-character string: ""
+      opRequest.setInput(inputValue);
+      request.addOperations(opRequest);
+
+      const result = await shim.executeAsync(request);
+
+      const opResult = result.getResultsList()[0];
+      expect(opResult.hasSuccess()).toBe(true);
+      const captured = JSON.parse(opResult.getSuccess()!.getResult()!.getValue());
+      expect(captured).toEqual({ hadInput: true, value: "" });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a bug in the entity executor where an entity **operation whose input is an empty `StringValue` crashes with `SyntaxError: Unexpected end of JSON input`** and is rolled back, instead of being executed with no input.

## Why this fix is needed

`TaskEntityShim.executeOperation()` parsed the operation input like this:

```ts
const inputValue = opRequest.getInput();
const input = inputValue ? JSON.parse(inputValue.getValue()) : undefined;
```

The `inputValue ?` guard is meant to handle the "no input" case, but it only guards against `undefined`. A protobuf `StringValue` is **always a truthy object** — even when it wraps an empty string. So when a sidecar/scheduler (or another language SDK) sends an operation whose input field is an empty `StringValue` (`getValue() === ""`), the guard passes and the code calls `JSON.parse("")`, which throws:

```
SyntaxError: Unexpected end of JSON input
```

The `try/catch` in `executeOperation()` then converts that into an operation **failure** and **rolls back** the state/actions for that operation. The caller receives a confusing `SyntaxError` for what should have been a successful, no-input operation.

This is also inconsistent with the rest of the codebase:
- The orchestration and activity executors parse inputs through the shared `parseJsonField()` helper in `utils/pb-helper.util.ts`.
- Even the same file's `getSerializedState()` already guards against empty strings — only the operation-input path did not.

### Impact
- **Severity:** Medium — entity operations incorrectly fail and roll back when they should succeed with no input.
- **Scenarios affected:** operations received from a sidecar/scheduler that sends an empty `StringValue` for the input field; cross-SDK interop where another language SDK produces empty input wrappers; any protobuf construction that sets an empty `StringValue` instead of omitting the field entirely.

## The fix

Replace the inline `JSON.parse` with the shared `parseJsonField()` helper:

```ts
const inputValue = opRequest.getInput();
const input = parseJsonField(inputValue);
```

`parseJsonField()`:
1. Returns `undefined` for a `null`/`undefined` **or empty** `StringValue` — so an empty wrapper is treated as "no input".
2. Wraps genuine JSON parse errors with a contextual message and preserves the original error via `cause` (invalid JSON still fails, as before, just with a clearer message).
3. Aligns entity input parsing with how the orchestration and activity executors already handle inputs.

Because `parseJsonField()` returns `undefined` for an empty wrapper, `operation.hasInput` becomes `false` and the entity method is dispatched with no argument — matching the intended "no input" semantics.

## Tests

Added a new `empty operation input` suite to `entity-executor.spec.ts`:
- an empty `StringValue` input no longer throws `SyntaxError` — the operation now succeeds (regression test for the reported bug);
- the dispatched operation receives **no input** (`hasInput === false`);
- a genuine empty-string JSON value (`'""'`) is still delivered to the operation as `""` — guarding against over-eagerly dropping legitimate empty-string input.

### Validation
- `npm run build:core` — compiles cleanly.
- `eslint` on the changed files — clean.
- Full core unit suite — **1052 tests pass** (59 suites), including the 3 new tests.

Fixes #238