### PR TITLE
fix: clear stale in-memory purge queue entries

### DIFF
--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -243,6 +243,11 @@ export class InMemoryOrchestrationBackend {
     }
 
     this.instances.delete(instanceId);
+    this.orchestrationQueueSet.delete(instanceId);
+    const queueIndex = this.orchestrationQueue.indexOf(instanceId);
+    if (queueIndex >= 0) {
+      this.orchestrationQueue.splice(queueIndex, 1);
+    }
     this.stateWaiters.delete(instanceId);
     this.cancelInstanceTimers(instanceId);
     return true;

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -513,6 +513,37 @@ describe("In-Memory Backend", () => {
     expect(state).toBeUndefined();
   });
 
+  it("should clear stale queued work when purging completed orchestrations", async () => {
+    const orchestrator: TOrchestrator = async (_: OrchestrationContext, input: number) => {
+      return input * 2;
+    };
+    const instanceId = "purge-queue-cleanup-test-id";
+
+    worker.addOrchestrator(orchestrator);
+    await worker.start();
+
+    await client.scheduleNewOrchestration(orchestrator, 1, instanceId);
+    const initialState = await client.waitForOrchestrationCompletion(instanceId, true, 10);
+    expect(initialState?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+
+    await worker.stop();
+    await client.raiseOrchestrationEvent(instanceId, "late-event", "ignored");
+    expect((backend as any).orchestrationQueue).toContain(instanceId);
+    expect((backend as any).orchestrationQueueSet.has(instanceId)).toBe(true);
+
+    const result = await client.purgeOrchestration(instanceId);
+    expect(result.deletedInstanceCount).toEqual(1);
+    expect((backend as any).orchestrationQueue).not.toContain(instanceId);
+    expect((backend as any).orchestrationQueueSet.has(instanceId)).toBe(false);
+
+    await client.scheduleNewOrchestration(orchestrator, 21, instanceId);
+    await worker.start();
+
+    const recreatedState = await client.waitForOrchestrationCompletion(instanceId, true, 10);
+    expect(recreatedState?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(recreatedState?.serializedOutput).toEqual(JSON.stringify(42));
+  });
+
   it("should cancel pending timers when purging a terminated orchestration", async () => {
     const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
       // Create a timer far in the future — it will still be pending when we terminate


### PR DESCRIPTION
## Summary

Fixes a stale work-queue entry bug in the in-memory testing backend purge path.

`InMemoryOrchestrationBackend.purge()` previously removed the orchestration instance state, state waiters, and instance timers, but it did not remove the instance ID from `orchestrationQueue` or `orchestrationQueueSet`. Because `enqueueOrchestration()` uses `orchestrationQueueSet` as a deduplication guard, a purged instance could leave behind a stale set entry that caused a newly created orchestration with the same instance ID to silently skip enqueueing.

## Why this matters

The trigger scenario is:

1. An orchestration completes.
2. A later event or completion queues that same completed instance ID.
3. The completed instance is purged.
4. A new orchestration is created with the same ID.
5. The stale `orchestrationQueueSet` entry makes `enqueueOrchestration()` a no-op, so the new instance never gets processed and appears to hang.

This affects the in-memory testing infrastructure and can make tests silently stall when they purge and recreate an orchestration with the same ID.

## Fix

`purge()` now removes the instance ID from both queue structures before deleting waiters/timers:

- Deletes the ID from `orchestrationQueueSet`.
- Removes the ID from `orchestrationQueue` if present.

This mirrors the queue cleanup behavior already present in `reset()` while preserving the rest of the purge semantics.

## Tests

Added a regression test that:

1. Completes an orchestration.
2. Stops the worker and raises a late event to leave the completed ID in the queue/set.
3. Purges the completed instance and verifies both queue structures are cleaned.
4. Recreates the same instance ID and verifies it is processed to completion.

Validation run:

- `npm run build:core`
- `npx eslint packages\durabletask-js\src\testing\in-memory-backend.ts packages\durabletask-js\test\in-memory-backend.spec.ts`
- `npx jest --runInBand --runTestsByPath .\test\in-memory-backend.spec.ts --testNamePattern "should clear stale queued work"`
- `npx jest --runInBand`

Fixes #249