### PR TITLE
Fix #292: align core Task/TimerTask public shape (result/isCompleted/isFaulted, cancellable TimerTask)

### DIFF
--- a/packages/durabletask-js/src/index.ts
+++ b/packages/durabletask-js/src/index.ts
@@ -76,6 +76,7 @@ export { FailureDetails, TaskFailureDetails } from "./task/failure-details";
 // Task utilities
 export { getName, whenAll, whenAny } from "./task";
 export { Task } from "./task/task";
+export { TimerTask } from "./task/timer-task";
 
 // Retry policies and task options
 export {

--- a/packages/durabletask-js/src/task/context/orchestration-context.ts
+++ b/packages/durabletask-js/src/task/context/orchestration-context.ts
@@ -8,6 +8,7 @@ import { Logger } from "../../types/logger.type";
 import { ReplaySafeLogger } from "../../types/replay-safe-logger";
 import { TaskOptions, SubOrchestrationOptions } from "../options";
 import { Task } from "../task";
+import { TimerTask } from "../timer-task";
 import { OrchestrationEntityFeature } from "../../entities/orchestration-entity-feature";
 import { compareVersions } from "../../utils/versioning.util";
 
@@ -108,9 +109,9 @@ export abstract class OrchestrationContext {
    * Create a timer task that will fire at a specified time.
    *
    * @param {Date | number} fireAt The time at which the timer should fire.
-   * @returns {Task} A Durable Timer task that schedules the timer to wake up the orchestrator
+   * @returns {TimerTask} A cancellable Durable Timer task that schedules the timer to wake up the orchestrator
    */
-  abstract createTimer(fireAt: Date | number): Task<any>;
+  abstract createTimer(fireAt: Date | number): TimerTask;
 
   /**
    * Schedule an activity for execution.

--- a/packages/durabletask-js/src/task/context/orchestration-context.ts
+++ b/packages/durabletask-js/src/task/context/orchestration-context.ts
@@ -108,6 +108,13 @@ export abstract class OrchestrationContext {
   /**
    * Create a timer task that will fire at a specified time.
    *
+   * @remarks
+   * This abstract method is implemented only by the SDK's own orchestration
+   * context (`RuntimeOrchestrationContext`); orchestrator code consumes a context
+   * instance and does not subclass it. The return type is the concrete
+   * {@link TimerTask} (which is a `Task`) so callers can cancel the timer — this
+   * narrowing is safe for all callers.
+   *
    * @param {Date | number} fireAt The time at which the timer should fire.
    * @returns {TimerTask} A cancellable Durable Timer task that schedules the timer to wake up the orchestrator
    */

--- a/packages/durabletask-js/src/task/task.ts
+++ b/packages/durabletask-js/src/task/task.ts
@@ -55,7 +55,7 @@ export class Task<T> {
    * Durable Functions `Task.result` shape.
    */
   get result(): T | undefined {
-    return this._isComplete ? this._result : undefined;
+    return this._isComplete && !this._exception ? this._result : undefined;
   }
 
   /**

--- a/packages/durabletask-js/src/task/task.ts
+++ b/packages/durabletask-js/src/task/task.ts
@@ -33,6 +33,32 @@ export class Task<T> {
   }
 
   /**
+   * Alias of {@link isComplete} that matches the v3 Durable Functions `Task` shape.
+   * Note that completion is not equivalent to success.
+   */
+  get isCompleted(): boolean {
+    return this._isComplete;
+  }
+
+  /**
+   * Alias of {@link isFailed} that matches the v3 Durable Functions `Task` shape.
+   */
+  get isFaulted(): boolean {
+    return this.isFailed;
+  }
+
+  /**
+   * The result of the task if it has completed successfully, otherwise `undefined`.
+   *
+   * Unlike {@link getResult}, this getter never throws: it returns `undefined`
+   * while the task is still pending and for a failed task. This matches the v3
+   * Durable Functions `Task.result` shape.
+   */
+  get result(): T | undefined {
+    return this._isComplete ? this._result : undefined;
+  }
+
+  /**
    * Get the result of the task
    */
   getResult(): T {

--- a/packages/durabletask-js/src/task/timer-task.ts
+++ b/packages/durabletask-js/src/task/timer-task.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as pb from "../proto/orchestrator_service_pb";
+import { CompletableTask } from "./completable-task";
+
+/**
+ * Minimal structural view of the orchestration context bookkeeping that a
+ * {@link TimerTask} needs in order to cancel a pending timer.
+ *
+ * This is intentionally a narrow interface (rather than importing
+ * `RuntimeOrchestrationContext`) so that `TimerTask` has no circular dependency
+ * on the worker runtime. The concrete context satisfies it structurally.
+ */
+export interface TimerBookkeeping {
+  _pendingActions: Record<number, pb.OrchestratorAction>;
+  _pendingTasks: Record<number, CompletableTask<any>>;
+}
+
+/**
+ * A durable timer task returned by `OrchestrationContext.createTimer`.
+ *
+ * In addition to the normal {@link Task} surface, a `TimerTask` can be
+ * canceled. Canceling is the classic "timeout vs. work" pattern: when a racing
+ * task wins (e.g. via `whenAny`), the losing timeout timer is canceled so the
+ * orchestration is no longer waiting on it.
+ *
+ * @example Cancel the loser of a race
+ * ```typescript
+ * const timeoutTask = context.createTimer(expirationDate);
+ * const workTask = context.callActivity("DoWork");
+ * const winner = yield context.whenAny([timeoutTask, workTask]);
+ * if (winner === workTask && !timeoutTask.isCompleted) {
+ *   timeoutTask.cancel();
+ * }
+ * ```
+ */
+export class TimerTask extends CompletableTask<undefined> {
+  private readonly _bookkeeping: TimerBookkeeping;
+  private readonly _timerId: number;
+  private _isCanceled = false;
+
+  /**
+   * Creates a new TimerTask.
+   *
+   * @param bookkeeping - The orchestration context bookkeeping holding the pending
+   *   actions and tasks (the concrete `RuntimeOrchestrationContext` satisfies this).
+   * @param timerId - The sequence id of the timer's `CreateTimer` action / pending task.
+   */
+  constructor(bookkeeping: TimerBookkeeping, timerId: number) {
+    super();
+    this._bookkeeping = bookkeeping;
+    this._timerId = timerId;
+  }
+
+  /**
+   * Whether this timer has been canceled via {@link cancel}.
+   */
+  get isCanceled(): boolean {
+    return this._isCanceled;
+  }
+
+  /**
+   * Cancels this timer so the orchestration stops waiting on it.
+   *
+   * Semantics:
+   * - If the timer's `CreateTimer` action has not yet been dispatched to the
+   *   sidecar (i.e. it is still pending in the current turn), it is removed so
+   *   the timer is never scheduled at all.
+   * - If the timer was already scheduled on a prior turn, it is removed from the
+   *   pending-task set so the orchestrator no longer waits on it; the backend
+   *   timer is reaped when the orchestration completes, and a late `TimerFired`
+   *   event is ignored because no pending task remains for it.
+   *
+   * This is deterministic and replay-safe: it consumes no sequence number and
+   * only deletes bookkeeping entries by key. Calling `cancel()` after the timer
+   * has already fired (completed) or after it was already canceled is a no-op.
+   */
+  cancel(): void {
+    if (this._isComplete || this._isCanceled) {
+      // Already fired or already canceled — nothing to do.
+      return;
+    }
+
+    this._isCanceled = true;
+
+    // Drop the pending CreateTimer action (if it has not been dispatched yet)
+    // so it is not scheduled, and stop tracking this timer as outstanding so
+    // the orchestrator is no longer waiting on it.
+    delete this._bookkeeping._pendingActions[this._timerId];
+    delete this._bookkeeping._pendingTasks[this._timerId];
+  }
+}

--- a/packages/durabletask-js/src/task/timer-task.ts
+++ b/packages/durabletask-js/src/task/timer-task.ts
@@ -18,9 +18,11 @@ import { CompletableTask } from "./completable-task";
  *
  * @example Cancel the loser of a race
  * ```typescript
+ * import { whenAny } from "@microsoft/durabletask-js";
+ *
  * const timeoutTask = context.createTimer(expirationDate);
  * const workTask = context.callActivity("DoWork");
- * const winner = yield context.whenAny([timeoutTask, workTask]);
+ * const winner = yield whenAny([timeoutTask, workTask]);
  * if (winner === workTask && !timeoutTask.isCompleted) {
  *   timeoutTask.cancel();
  * }
@@ -44,6 +46,8 @@ export class TimerTask extends CompletableTask<undefined> {
    * pending `CreateTimer` action and pending-task entry, so this class needs no
    * knowledge of the context's internals.
    *
+   * @internal Invoked by the orchestration context when the timer is created.
+   *   Not part of the public `TimerTask` surface; orchestrator code must not call it.
    * @param handler - Called once, when {@link cancel} first transitions the timer
    *   to the canceled state.
    */

--- a/packages/durabletask-js/src/task/timer-task.ts
+++ b/packages/durabletask-js/src/task/timer-task.ts
@@ -1,21 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as pb from "../proto/orchestrator_service_pb";
 import { CompletableTask } from "./completable-task";
-
-/**
- * Minimal structural view of the orchestration context bookkeeping that a
- * {@link TimerTask} needs in order to cancel a pending timer.
- *
- * This is intentionally a narrow interface (rather than importing
- * `RuntimeOrchestrationContext`) so that `TimerTask` has no circular dependency
- * on the worker runtime. The concrete context satisfies it structurally.
- */
-export interface TimerBookkeeping {
-  _pendingActions: Record<number, pb.OrchestratorAction>;
-  _pendingTasks: Record<number, CompletableTask<any>>;
-}
 
 /**
  * A durable timer task returned by `OrchestrationContext.createTimer`.
@@ -24,6 +10,11 @@ export interface TimerBookkeeping {
  * canceled. Canceling is the classic "timeout vs. work" pattern: when a racing
  * task wins (e.g. via `whenAny`), the losing timeout timer is canceled so the
  * orchestration is no longer waiting on it.
+ *
+ * `TimerTask` is decoupled from the orchestration context's internal
+ * bookkeeping: the context injects a cancel handler via {@link setCancelHandler}
+ * and this class knows nothing about pending actions or tasks. This mirrors the
+ * `CancellableTask.set_cancel_handler` pattern in the Python SDK.
  *
  * @example Cancel the loser of a race
  * ```typescript
@@ -36,22 +27,8 @@ export interface TimerBookkeeping {
  * ```
  */
 export class TimerTask extends CompletableTask<undefined> {
-  private readonly _bookkeeping: TimerBookkeeping;
-  private readonly _timerId: number;
+  private _cancelHandler?: () => void;
   private _isCanceled = false;
-
-  /**
-   * Creates a new TimerTask.
-   *
-   * @param bookkeeping - The orchestration context bookkeeping holding the pending
-   *   actions and tasks (the concrete `RuntimeOrchestrationContext` satisfies this).
-   * @param timerId - The sequence id of the timer's `CreateTimer` action / pending task.
-   */
-  constructor(bookkeeping: TimerBookkeeping, timerId: number) {
-    super();
-    this._bookkeeping = bookkeeping;
-    this._timerId = timerId;
-  }
 
   /**
    * Whether this timer has been canceled via {@link cancel}.
@@ -61,20 +38,37 @@ export class TimerTask extends CompletableTask<undefined> {
   }
 
   /**
+   * Registers the handler invoked when this timer is first canceled.
+   *
+   * The orchestration context supplies a closure that removes the timer's
+   * pending `CreateTimer` action and pending-task entry, so this class needs no
+   * knowledge of the context's internals.
+   *
+   * @param handler - Called once, when {@link cancel} first transitions the timer
+   *   to the canceled state.
+   */
+  setCancelHandler(handler: () => void): void {
+    this._cancelHandler = handler;
+  }
+
+  /**
    * Cancels this timer so the orchestration stops waiting on it.
    *
-   * Semantics:
-   * - If the timer's `CreateTimer` action has not yet been dispatched to the
-   *   sidecar (i.e. it is still pending in the current turn), it is removed so
-   *   the timer is never scheduled at all.
-   * - If the timer was already scheduled on a prior turn, it is removed from the
-   *   pending-task set so the orchestrator no longer waits on it; the backend
-   *   timer is reaped when the orchestration completes, and a late `TimerFired`
-   *   event is ignored because no pending task remains for it.
+   * The actual bookkeeping is performed by the cancel handler injected via
+   * {@link setCancelHandler}. The orchestration context's handler:
+   * - Removes the timer's `CreateTimer` action if it has not yet been dispatched
+   *   to the sidecar (i.e. it is still pending in the current turn), so the timer
+   *   is never scheduled at all.
+   * - Otherwise drops the timer from the pending-task set so the orchestrator no
+   *   longer waits on it; the backend timer is reaped when the orchestration
+   *   completes, and a late `TimerFired` event is ignored because no pending task
+   *   remains for it.
    *
    * This is deterministic and replay-safe: it consumes no sequence number and
-   * only deletes bookkeeping entries by key. Calling `cancel()` after the timer
-   * has already fired (completed) or after it was already canceled is a no-op.
+   * only runs the injected handler. Cancel does NOT mark the task complete
+   * (`isCompleted` stays false). Calling `cancel()` after the timer has already
+   * fired (completed) or after it was already canceled is a no-op, so the handler
+   * runs at most once.
    */
   cancel(): void {
     if (this._isComplete || this._isCanceled) {
@@ -83,11 +77,6 @@ export class TimerTask extends CompletableTask<undefined> {
     }
 
     this._isCanceled = true;
-
-    // Drop the pending CreateTimer action (if it has not been dispatched yet)
-    // so it is not scheduled, and stop tracking this timer as outstanding so
-    // the orchestrator is no longer waiting on it.
-    delete this._bookkeeping._pendingActions[this._timerId];
-    delete this._bookkeeping._pendingTasks[this._timerId];
+    this._cancelHandler?.();
   }
 }

--- a/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
+++ b/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
@@ -335,7 +335,11 @@ export class RuntimeOrchestrationContext extends OrchestrationContext {
     const action = ph.newCreateTimerAction(id, fireAtDate);
     this._pendingActions[action.getId()] = action;
 
-    const timerTask = new TimerTask(this, id);
+    const timerTask = new TimerTask();
+    timerTask.setCancelHandler(() => {
+      delete this._pendingActions[id];
+      delete this._pendingTasks[id];
+    });
     this._pendingTasks[id] = timerTask;
 
     return timerTask;

--- a/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
+++ b/packages/durabletask-js/src/worker/runtime-orchestration-context.ts
@@ -12,6 +12,7 @@ import { RetryTaskBase, RetryTaskType } from "../task/retry-task-base";
 import { RetryableTask } from "../task/retryable-task";
 import { RetryHandlerTask } from "../task/retry-handler-task";
 import { RetryTimerTask } from "../task/retry-timer-task";
+import { TimerTask } from "../task/timer-task";
 import { TaskOptions, SubOrchestrationOptions, isRetryPolicy, isRetryHandler } from "../task/options";
 import { toAsyncRetryHandler } from "../task/retry/retry-handler";
 import { TActivity } from "../types/activity.type";
@@ -306,7 +307,7 @@ export class RuntimeOrchestrationContext extends OrchestrationContext {
    * @param fireAt Date The date when the timer should fire
    * @returns
    */
-  createTimer(fireAt: number | Date): Task<any> {
+  createTimer(fireAt: number | Date): TimerTask {
     const id = this.nextSequenceNumber();
 
     let fireAtDate: Date;
@@ -334,7 +335,7 @@ export class RuntimeOrchestrationContext extends OrchestrationContext {
     const action = ph.newCreateTimerAction(id, fireAtDate);
     this._pendingActions[action.getId()] = action;
 
-    const timerTask = new CompletableTask();
+    const timerTask = new TimerTask(this, id);
     this._pendingTasks[id] = timerTask;
 
     return timerTask;

--- a/packages/durabletask-js/test/orchestration_executor.spec.ts
+++ b/packages/durabletask-js/test/orchestration_executor.spec.ts
@@ -2367,6 +2367,147 @@ describe("EventSent Handler", () => {
     expect(failureDetails?.getErrortype()).toEqual("NonDeterminismError");
     expect(failureDetails?.getErrormessage()).toMatch(/sendEvent/);
   });
+
+  // Regression coverage for issue #292: the classic "activity vs. timeout" race
+  // where the winner cancels the loser timer (cancellable TimerTask).
+  it("should complete the timer-vs-activity race when the activity wins and the loser timer is canceled", async () => {
+    const hello = (_: any, name: string) => `Hello ${name}!`;
+
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const timeoutTask = ctx.createTimer(new Date(ctx.currentUtcDateTime.getTime() + 24 * 60 * 60 * 1000));
+      const activityTask = ctx.callActivity(hello, "Tokyo");
+
+      const winner = yield whenAny([timeoutTask, activityTask]);
+
+      // Identity must be preserved: whenAny returns the exact activity task instance.
+      if (winner === activityTask) {
+        if (!timeoutTask.isCompleted) {
+          timeoutTask.cancel();
+        }
+        return activityTask.getResult();
+      }
+      return "timed out";
+    };
+
+    const registry = new Registry();
+    const orchestratorName = registry.addOrchestrator(orchestrator);
+    const activityName = registry.addActivity(hello);
+
+    // Turn 1: schedules the timer (action 1) and the activity (action 2), then yields on whenAny.
+    const startTime = new Date(2020, 0, 1, 12, 0, 0);
+    let executor = new OrchestrationExecutor(registry, testLogger);
+    let result = await executor.execute(TEST_INSTANCE_ID, [], [
+      newOrchestratorStartedEvent(startTime),
+      newExecutionStartedEvent(orchestratorName, TEST_INSTANCE_ID),
+    ]);
+    expect(result.actions.length).toEqual(2);
+    expect(result.actions[0].hasCreatetimer()).toBeTruthy();
+    expect(result.actions[1].hasScheduletask()).toBeTruthy();
+
+    // Turn 2: the activity completes first; the timer has NOT fired.
+    const timerFireAt = new Date(startTime.getTime() + 24 * 60 * 60 * 1000);
+    const oldEvents = [
+      newOrchestratorStartedEvent(startTime),
+      newExecutionStartedEvent(orchestratorName, TEST_INSTANCE_ID),
+      newTimerCreatedEvent(1, timerFireAt),
+      newTaskScheduledEvent(2, activityName, JSON.stringify("Tokyo")),
+    ];
+    const encodedOutput = JSON.stringify(hello(null, "Tokyo"));
+    executor = new OrchestrationExecutor(registry, testLogger);
+    result = await executor.execute(TEST_INSTANCE_ID, oldEvents, [newTaskCompletedEvent(2, encodedOutput)]);
+
+    // A single CompleteOrchestration action, carrying the activity's result, and
+    // no leftover CreateTimer action (the canceled timer must not be rescheduled).
+    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
+    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+    expect(completeAction?.getResult()?.getValue()).toEqual(encodedOutput);
+    expect(result.actions.some((a) => a.hasCreatetimer())).toBe(false);
+  });
+
+  it("should complete normally when the timer wins the race (no regression to timer firing)", async () => {
+    const hello = (_: any, name: string) => `Hello ${name}!`;
+
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const timeoutTask = ctx.createTimer(new Date(ctx.currentUtcDateTime.getTime() + 24 * 60 * 60 * 1000));
+      const activityTask = ctx.callActivity(hello, "Tokyo");
+
+      const winner = yield whenAny([timeoutTask, activityTask]);
+
+      if (winner === timeoutTask) {
+        return "timed out";
+      }
+      return activityTask.getResult();
+    };
+
+    const registry = new Registry();
+    const orchestratorName = registry.addOrchestrator(orchestrator);
+    const activityName = registry.addActivity(hello);
+
+    const startTime = new Date(2020, 0, 1, 12, 0, 0);
+    const timerFireAt = new Date(startTime.getTime() + 24 * 60 * 60 * 1000);
+    const oldEvents = [
+      newOrchestratorStartedEvent(startTime),
+      newExecutionStartedEvent(orchestratorName, TEST_INSTANCE_ID),
+      newTimerCreatedEvent(1, timerFireAt),
+      newTaskScheduledEvent(2, activityName, JSON.stringify("Tokyo")),
+    ];
+
+    // The timer fires first: the orchestration should still complete via the timeout branch.
+    const executor = new OrchestrationExecutor(registry, testLogger);
+    const result = await executor.execute(TEST_INSTANCE_ID, oldEvents, [newTimerFiredEvent(1, timerFireAt)]);
+
+    const completeAction = getAndValidateSingleCompleteOrchestrationAction(result);
+    expect(completeAction?.getOrchestrationstatus()).toEqual(pb.OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+    expect(completeAction?.getResult()?.getValue()).toEqual(JSON.stringify("timed out"));
+  });
+
+  it("should ignore a fired event for a canceled timer (replay-safe) and keep running", async () => {
+    const hello = (_: any, name: string) => `Hello ${name}!`;
+
+    // The orchestration cancels the timer, then continues with more work. A late
+    // TimerFired event for the canceled timer must be ignored (no crash, no
+    // premature completion) rather than resuming the orchestrator.
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const timeoutTask = ctx.createTimer(new Date(ctx.currentUtcDateTime.getTime() + 24 * 60 * 60 * 1000));
+      const activityTask = ctx.callActivity(hello, "Tokyo");
+
+      const winner = yield whenAny([timeoutTask, activityTask]);
+      if (winner === activityTask && !timeoutTask.isCompleted) {
+        timeoutTask.cancel();
+      }
+
+      // Continue after canceling the timer.
+      const second = yield ctx.callActivity(hello, "Seattle");
+      return second;
+    };
+
+    const registry = new Registry();
+    const orchestratorName = registry.addOrchestrator(orchestrator);
+    const activityName = registry.addActivity(hello);
+
+    const startTime = new Date(2020, 0, 1, 12, 0, 0);
+    const timerFireAt = new Date(startTime.getTime() + 24 * 60 * 60 * 1000);
+    const oldEvents = [
+      newOrchestratorStartedEvent(startTime),
+      newExecutionStartedEvent(orchestratorName, TEST_INSTANCE_ID),
+      newTimerCreatedEvent(1, timerFireAt),
+      newTaskScheduledEvent(2, activityName, JSON.stringify("Tokyo")),
+    ];
+
+    // The first activity completes AND the (canceled) timer fires in the same batch.
+    const encodedOutput = JSON.stringify(hello(null, "Tokyo"));
+    const executor = new OrchestrationExecutor(registry, testLogger);
+    const result = await executor.execute(TEST_INSTANCE_ID, oldEvents, [
+      newTaskCompletedEvent(2, encodedOutput),
+      newTimerFiredEvent(1, timerFireAt),
+    ]);
+
+    // The fired canceled timer is ignored; the orchestration schedules the second
+    // activity and is NOT complete.
+    expect(result.actions.length).toEqual(1);
+    expect(result.actions[0].hasScheduletask()).toBeTruthy();
+    expect(result.actions.some((a) => a.hasCompleteorchestration())).toBe(false);
+  });
 });
 
 function getAndValidateSingleCompleteOrchestrationAction(

--- a/packages/durabletask-js/test/task.spec.ts
+++ b/packages/durabletask-js/test/task.spec.ts
@@ -138,6 +138,14 @@ describe("Task (base class)", () => {
       expect(() => task.result).not.toThrow();
       expect(task.result).toBeUndefined();
     });
+
+    it("result returns undefined for a failed task even if _result was set", () => {
+      const t = new CompletableTask<string>();
+      t._result = "stale";
+      t.fail("boom");
+      expect(t.result).toBeUndefined();
+      expect(t.isFaulted).toBe(true);
+    });
   });
 
   describe("isCompleted / isFaulted (v3 aliases)", () => {

--- a/packages/durabletask-js/test/task.spec.ts
+++ b/packages/durabletask-js/test/task.spec.ts
@@ -113,6 +113,61 @@ describe("Task (base class)", () => {
       expect(task.isFailed).toBe(true);
     });
   });
+
+  // v3 Durable Functions-aligned aliases (see issue #292).
+  describe("result (v3 alias)", () => {
+    it("should return undefined (not throw) when the task is not complete", () => {
+      const task = new Task<number>();
+      expect(() => task.result).not.toThrow();
+      expect(task.result).toBeUndefined();
+    });
+
+    it("should return the value when the task completed successfully", () => {
+      const task = new Task<number>();
+      task._result = 42;
+      task._isComplete = true;
+
+      expect(task.result).toBe(42);
+    });
+
+    it("should return undefined (not throw) when the task has failed", () => {
+      const task = new Task<number>();
+      task._exception = new TaskFailedError("boom", makeFailureDetails());
+      task._isComplete = true;
+
+      expect(() => task.result).not.toThrow();
+      expect(task.result).toBeUndefined();
+    });
+  });
+
+  describe("isCompleted / isFaulted (v3 aliases)", () => {
+    it("isCompleted should mirror isComplete across states", () => {
+      const task = new Task<number>();
+      expect(task.isCompleted).toBe(false);
+
+      task._isComplete = true;
+      expect(task.isCompleted).toBe(true);
+      expect(task.isCompleted).toBe(task.isComplete);
+    });
+
+    it("isFaulted should mirror isFailed across states", () => {
+      const task = new Task<number>();
+      expect(task.isFaulted).toBe(false);
+
+      task._exception = new TaskFailedError("err", makeFailureDetails());
+      expect(task.isFaulted).toBe(true);
+      expect(task.isFaulted).toBe(task.isFailed);
+    });
+
+    it("isFaulted should be false for a successfully completed task", () => {
+      const task = new Task<number>();
+      task._result = 1;
+      task._isComplete = true;
+
+      expect(task.isCompleted).toBe(true);
+      expect(task.isFaulted).toBe(false);
+    });
+  });
 });
 
 describe("CompletableTask", () => {

--- a/packages/durabletask-js/test/timer-task.spec.ts
+++ b/packages/durabletask-js/test/timer-task.spec.ts
@@ -1,27 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as pb from "../src/proto/orchestrator_service_pb";
 import { CompletableTask } from "../src/task/completable-task";
-import { TimerTask, TimerBookkeeping } from "../src/task/timer-task";
+import { TimerTask } from "../src/task/timer-task";
+import { RuntimeOrchestrationContext } from "../src/worker/runtime-orchestration-context";
 
-/**
- * Minimal fake bookkeeping that mirrors the fields TimerTask.cancel() touches on
- * the real RuntimeOrchestrationContext.
- */
-function makeBookkeeping(): TimerBookkeeping {
-  return {
-    _pendingActions: {} as Record<number, pb.OrchestratorAction>,
-    _pendingTasks: {} as Record<number, CompletableTask<any>>,
-  };
-}
+// A far-future fire time so timers created in these tests never fire on their own.
+const FUTURE_FIRE_AT = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
 describe("TimerTask", () => {
-  const TIMER_ID = 1;
-
   it("should start incomplete, not failed, and not canceled", () => {
-    const bookkeeping = makeBookkeeping();
-    const timer = new TimerTask(bookkeeping, TIMER_ID);
+    const timer = new TimerTask();
 
     expect(timer.isComplete).toBe(false);
     expect(timer.isCompleted).toBe(false);
@@ -30,34 +19,54 @@ describe("TimerTask", () => {
   });
 
   it("should be a Task/CompletableTask instance (identity preserving, no wrapper)", () => {
-    const bookkeeping = makeBookkeeping();
-    const timer = new TimerTask(bookkeeping, TIMER_ID);
+    const timer = new TimerTask();
 
     // TimerTask must extend CompletableTask so whenAny/whenAll return the real
     // instance and `winner === timerTask` identity holds for callers.
     expect(timer).toBeInstanceOf(CompletableTask);
   });
 
+  it("should return the same TimerTask instance that the context stores in _pendingTasks", () => {
+    // Identity: createTimer must hand back the exact instance it tracks so that
+    // `winner === timerTask` holds after whenAny.
+    const ctx = new RuntimeOrchestrationContext("test-instance");
+    const timer = ctx.createTimer(FUTURE_FIRE_AT);
+    const timerId = ctx._sequenceNumber;
+
+    expect(ctx._pendingTasks[timerId]).toBe(timer);
+  });
+
   describe("cancel()", () => {
-    it("should flip isCanceled and drop the pending action and pending task", () => {
-      const bookkeeping = makeBookkeeping();
-      const action = new pb.OrchestratorAction();
-      action.setId(TIMER_ID);
-      const timer = new TimerTask(bookkeeping, TIMER_ID);
-      bookkeeping._pendingActions[TIMER_ID] = action;
-      bookkeeping._pendingTasks[TIMER_ID] = timer;
+    it("should flip isCanceled and run the injected cancel handler once", () => {
+      const timer = new TimerTask();
+      const cancelHandler = jest.fn();
+      timer.setCancelHandler(cancelHandler);
 
       timer.cancel();
 
       expect(timer.isCanceled).toBe(true);
-      expect(bookkeeping._pendingActions[TIMER_ID]).toBeUndefined();
-      expect(bookkeeping._pendingTasks[TIMER_ID]).toBeUndefined();
+      expect(cancelHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("should drop the pending CreateTimer action and pending task via the context handler", () => {
+      // Drive a real context so the injected closure exercises the actual deletion.
+      const ctx = new RuntimeOrchestrationContext("test-instance");
+      const timer = ctx.createTimer(FUTURE_FIRE_AT);
+      const timerId = ctx._sequenceNumber;
+
+      expect(ctx._pendingActions[timerId]).toBeDefined();
+      expect(ctx._pendingTasks[timerId]).toBe(timer);
+
+      timer.cancel();
+
+      expect(timer.isCanceled).toBe(true);
+      expect(ctx._pendingActions[timerId]).toBeUndefined();
+      expect(ctx._pendingTasks[timerId]).toBeUndefined();
     });
 
     it("should not mark the timer complete (isCompleted stays false, isFaulted false)", () => {
-      const bookkeeping = makeBookkeeping();
-      const timer = new TimerTask(bookkeeping, TIMER_ID);
-      bookkeeping._pendingTasks[TIMER_ID] = timer;
+      const timer = new TimerTask();
+      timer.setCancelHandler(jest.fn());
 
       timer.cancel();
 
@@ -66,45 +75,49 @@ describe("TimerTask", () => {
       expect(timer.isFaulted).toBe(false);
     });
 
-    it("should be idempotent when called multiple times", () => {
-      const bookkeeping = makeBookkeeping();
-      const timer = new TimerTask(bookkeeping, TIMER_ID);
-      bookkeeping._pendingTasks[TIMER_ID] = timer;
+    it("should be idempotent when called multiple times (handler runs only once)", () => {
+      const timer = new TimerTask();
+      const cancelHandler = jest.fn();
+      timer.setCancelHandler(cancelHandler);
 
       timer.cancel();
       expect(() => timer.cancel()).not.toThrow();
+
       expect(timer.isCanceled).toBe(true);
+      expect(cancelHandler).toHaveBeenCalledTimes(1);
     });
 
     it("should not remove an unrelated pending action/task with a different id", () => {
-      const bookkeeping = makeBookkeeping();
-      const otherAction = new pb.OrchestratorAction();
-      otherAction.setId(2);
-      const otherTask = new CompletableTask<number>();
-      bookkeeping._pendingActions[2] = otherAction;
-      bookkeeping._pendingTasks[2] = otherTask;
+      // Two sibling timers on one real context; canceling one must not touch the other.
+      const ctx = new RuntimeOrchestrationContext("test-instance");
+      const firstTimer = ctx.createTimer(FUTURE_FIRE_AT);
+      const firstId = ctx._sequenceNumber;
+      const secondTimer = ctx.createTimer(FUTURE_FIRE_AT);
+      const secondId = ctx._sequenceNumber;
 
-      const timer = new TimerTask(bookkeeping, TIMER_ID);
-      bookkeeping._pendingTasks[TIMER_ID] = timer;
+      firstTimer.cancel();
 
-      timer.cancel();
-
-      // The sibling entries at id 2 must remain untouched.
-      expect(bookkeeping._pendingActions[2]).toBe(otherAction);
-      expect(bookkeeping._pendingTasks[2]).toBe(otherTask);
+      // The sibling entries at the other id must remain untouched.
+      expect(ctx._pendingActions[secondId]).toBeDefined();
+      expect(ctx._pendingTasks[secondId]).toBe(secondTimer);
+      // The canceled timer's entries are gone.
+      expect(ctx._pendingActions[firstId]).toBeUndefined();
+      expect(ctx._pendingTasks[firstId]).toBeUndefined();
     });
 
     it("should be a no-op after the timer has already fired (completed)", () => {
-      const bookkeeping = makeBookkeeping();
-      const timer = new TimerTask(bookkeeping, TIMER_ID);
+      const timer = new TimerTask();
+      const cancelHandler = jest.fn();
+      timer.setCancelHandler(cancelHandler);
 
       // Simulate the timer firing (handleTimerFired calls complete(undefined)).
       timer.complete(undefined);
 
       expect(() => timer.cancel()).not.toThrow();
-      // Canceling a fired timer must not flip isCanceled.
+      // Canceling a fired timer must not flip isCanceled or run the handler.
       expect(timer.isCanceled).toBe(false);
       expect(timer.isCompleted).toBe(true);
+      expect(cancelHandler).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/durabletask-js/test/timer-task.spec.ts
+++ b/packages/durabletask-js/test/timer-task.spec.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as pb from "../src/proto/orchestrator_service_pb";
+import { CompletableTask } from "../src/task/completable-task";
+import { TimerTask, TimerBookkeeping } from "../src/task/timer-task";
+
+/**
+ * Minimal fake bookkeeping that mirrors the fields TimerTask.cancel() touches on
+ * the real RuntimeOrchestrationContext.
+ */
+function makeBookkeeping(): TimerBookkeeping {
+  return {
+    _pendingActions: {} as Record<number, pb.OrchestratorAction>,
+    _pendingTasks: {} as Record<number, CompletableTask<any>>,
+  };
+}
+
+describe("TimerTask", () => {
+  const TIMER_ID = 1;
+
+  it("should start incomplete, not failed, and not canceled", () => {
+    const bookkeeping = makeBookkeeping();
+    const timer = new TimerTask(bookkeeping, TIMER_ID);
+
+    expect(timer.isComplete).toBe(false);
+    expect(timer.isCompleted).toBe(false);
+    expect(timer.isFailed).toBe(false);
+    expect(timer.isCanceled).toBe(false);
+  });
+
+  it("should be a Task/CompletableTask instance (identity preserving, no wrapper)", () => {
+    const bookkeeping = makeBookkeeping();
+    const timer = new TimerTask(bookkeeping, TIMER_ID);
+
+    // TimerTask must extend CompletableTask so whenAny/whenAll return the real
+    // instance and `winner === timerTask` identity holds for callers.
+    expect(timer).toBeInstanceOf(CompletableTask);
+  });
+
+  describe("cancel()", () => {
+    it("should flip isCanceled and drop the pending action and pending task", () => {
+      const bookkeeping = makeBookkeeping();
+      const action = new pb.OrchestratorAction();
+      action.setId(TIMER_ID);
+      const timer = new TimerTask(bookkeeping, TIMER_ID);
+      bookkeeping._pendingActions[TIMER_ID] = action;
+      bookkeeping._pendingTasks[TIMER_ID] = timer;
+
+      timer.cancel();
+
+      expect(timer.isCanceled).toBe(true);
+      expect(bookkeeping._pendingActions[TIMER_ID]).toBeUndefined();
+      expect(bookkeeping._pendingTasks[TIMER_ID]).toBeUndefined();
+    });
+
+    it("should not mark the timer complete (isCompleted stays false, isFaulted false)", () => {
+      const bookkeeping = makeBookkeeping();
+      const timer = new TimerTask(bookkeeping, TIMER_ID);
+      bookkeeping._pendingTasks[TIMER_ID] = timer;
+
+      timer.cancel();
+
+      expect(timer.isCanceled).toBe(true);
+      expect(timer.isCompleted).toBe(false);
+      expect(timer.isFaulted).toBe(false);
+    });
+
+    it("should be idempotent when called multiple times", () => {
+      const bookkeeping = makeBookkeeping();
+      const timer = new TimerTask(bookkeeping, TIMER_ID);
+      bookkeeping._pendingTasks[TIMER_ID] = timer;
+
+      timer.cancel();
+      expect(() => timer.cancel()).not.toThrow();
+      expect(timer.isCanceled).toBe(true);
+    });
+
+    it("should not remove an unrelated pending action/task with a different id", () => {
+      const bookkeeping = makeBookkeeping();
+      const otherAction = new pb.OrchestratorAction();
+      otherAction.setId(2);
+      const otherTask = new CompletableTask<number>();
+      bookkeeping._pendingActions[2] = otherAction;
+      bookkeeping._pendingTasks[2] = otherTask;
+
+      const timer = new TimerTask(bookkeeping, TIMER_ID);
+      bookkeeping._pendingTasks[TIMER_ID] = timer;
+
+      timer.cancel();
+
+      // The sibling entries at id 2 must remain untouched.
+      expect(bookkeeping._pendingActions[2]).toBe(otherAction);
+      expect(bookkeeping._pendingTasks[2]).toBe(otherTask);
+    });
+
+    it("should be a no-op after the timer has already fired (completed)", () => {
+      const bookkeeping = makeBookkeeping();
+      const timer = new TimerTask(bookkeeping, TIMER_ID);
+
+      // Simulate the timer firing (handleTimerFired calls complete(undefined)).
+      timer.complete(undefined);
+
+      expect(() => timer.cancel()).not.toThrow();
+      // Canceling a fired timer must not flip isCanceled.
+      expect(timer.isCanceled).toBe(false);
+      expect(timer.isCompleted).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #292.

The v4 core `Task` / `TimerTask` public shape dropped members that the Azure Functions
Durable JS **v3** programming model exposes, which blocks the compat layer (PR #282, not on
`main`). This aligns the **core** package (`packages/durabletask-js/`) so the compat layer can
consume real core types — no wrappers that would break `===` identity in the classic
`Task.any([...])` race.

> Scope note: the `azure-functions-durable` compat package is not on `main` (it lives in
> #282), so this PR makes the alignment in **core**; #282 will consume it.

## B1 — v3-aligned aliases on base `Task<T>` (additive, non-breaking)

| Added member | Behavior |
| --- | --- |
| `get result(): T \| undefined` | Value when completed, otherwise `undefined`. **Never throws** (distinct from `getResult()`, which throws when incomplete). Failed tasks return `undefined`. |
| `get isCompleted(): boolean` | Alias of `isComplete`. |
| `get isFaulted(): boolean` | Alias of `isFailed`. |

`getResult()` / `isComplete` / `isFailed` are unchanged.

## B2 — cancellable `TimerTask` primitive

- New `TimerTask extends CompletableTask<undefined>` exposing `cancel(): void` and
  `isCanceled: boolean`.
- `createTimer` now returns the **real** `TimerTask` instance that is stored in the context's
  `_pendingTasks`, so `whenAny` / `whenAll` return that exact object and
  `winner === timerTask` / `winner === activityTask` holds. **No wrapper / proxy** — identity
  is preserved.
- The public abstract `OrchestrationContext.createTimer` return type is widened
  `Task<any>` → `TimerTask` (additive; `TimerTask` is a `Task`, so existing
  `yield ctx.createTimer(...)` callers are unaffected).
- `TimerTask` is exported from the package entrypoint for the compat layer.

### How `cancel()` lets the orchestrator complete (deterministic & replay-safe)

- **Timer not yet dispatched (same turn as creation):** the `CreateTimer` action is still in
  `_pendingActions`; `cancel()` deletes it, so the timer is never scheduled.
- **Timer already dispatched (prior turn):** the backend timer is orphaned. `cancel()` removes
  the pending task so the orchestrator stops waiting; the generator returns, the orchestration
  completes, and the backend reaps outstanding timers on completion. A late `TimerFired` finds
  no pending task and hits the **existing** graceful "unexpected event → ignore" path in
  `handleTimerFired` — no code change there.
- **Determinism:** `cancel()` runs from deterministic orchestrator code, consumes **no**
  sequence number, and only deletes bookkeeping entries **by key**, so other action IDs are
  unaffected. No `NonDeterminismError` risk. (The DTFx wire protocol has no `CancelTimer`
  action; cancellation is an orchestrator-side concept, consistent with the .NET/Python SDKs.)
- To avoid a circular import with the worker runtime, `TimerTask` takes a minimal structural
  `TimerBookkeeping` interface (`{ _pendingActions; _pendingTasks }`) that the concrete context
  satisfies, plus the numeric timer id.

## Decisions needing maintainer sign-off

1. **Home of the v3 aliases.** `result` / `isCompleted` / `isFaulted` are added to the **core**
   public `Task` per the issue ("trivial, safe aliases"). Confirm core is the desired home
   (vs. compat-only).
2. **`cancel()` on an already-fired/completed timer.** DF v3 `DFTimerTask.cancel()` **throws**
   (`"Cannot cancel a completed task."`). This PR makes the core primitive an **idempotent
   no-op** (safer, and matches the requested regression test). The compat layer can re-add the
   throw for exact v3 parity. Confirm no-op is acceptable for the core primitive.
3. **Cancellation model.** `cancel()` does not mark the timer complete (`isCompleted` stays
   `false`, `isCanceled` becomes `true`) and relies on orchestration completion to reap an
   already-scheduled backend timer (no wire-level cancel). Confirm this semantic.

## Regression analysis (no regressions)

- `npm run build:core` ✅ · `npm run lint` ✅ · `npm run test:unit -w @microsoft/durabletask-js`
  ✅ (61 suites, 1086 tests).
- `whenAll` / `whenAny` unchanged; added an explicit assertion that `whenAny` returns the
  **same** child instance (identity) — both at task level and through the executor
  timer/activity race.
- Normal timer completion path unchanged (timer-wins race still completes; existing timer tests
  pass).
- `cancel()` before fire drops the pending timer and flips `isCanceled`; `cancel()` after fire
  and double-`cancel()` are safe no-ops; canceling one timer does not touch sibling ids.
- `result` never throws (undefined when incomplete/failed, value when completed);
  `isCompleted` / `isFaulted` reflect state.

## Tests

- `test/task.spec.ts`: `result` / `isCompleted` / `isFaulted` across incomplete / completed /
  failed.
- `test/timer-task.spec.ts` (new): `cancel()` removes action + task and flips `isCanceled`;
  idempotent; no-op after complete; sibling-id isolation; created object identity == stored
  pending task; `instanceof CompletableTask`.
- `test/orchestration_executor.spec.ts` (new cases): classic timer-vs-activity race — activity
  wins → `winner === activityTask`, loser timer canceled, single `CompleteOrchestration`, no
  leftover `CreateTimer`; timer-wins path still completes; replay-safe ignore of a fired
  canceled timer (orchestration keeps running).
