### PR TITLE
fix: trim additional tenant IDs from connection strings

### DIFF
--- a/packages/durabletask-js-azuremanaged/src/connection-string.ts
+++ b/packages/durabletask-js-azuremanaged/src/connection-string.ts
@@ -51,7 +51,10 @@ export class DurableTaskAzureManagedConnectionString {
     if (!value || value === "") {
       return undefined;
     }
-    return value.split(",");
+    return value
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t !== "");
   }
 
   /**

--- a/packages/durabletask-js-azuremanaged/test/unit/connection-string.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/connection-string.spec.ts
@@ -137,6 +137,36 @@ describe("DurableTaskAzureManagedConnectionString", () => {
 
       expect(tenants).toEqual(["tenant1", "tenant2"]);
     });
+
+    it("should trim whitespace from each tenant value", () => {
+      const connectionStringWithSpaces =
+        VALID_CONNECTION_STRING + ";AdditionallyAllowedTenants=tenant1, tenant2 , tenant3";
+
+      const connectionString = new DurableTaskAzureManagedConnectionString(connectionStringWithSpaces);
+      const tenants = connectionString.getAdditionallyAllowedTenants();
+
+      expect(tenants).toEqual(["tenant1", "tenant2", "tenant3"]);
+    });
+
+    it("should filter out empty entries from trailing commas", () => {
+      const connectionStringWithTrailingComma =
+        VALID_CONNECTION_STRING + ";AdditionallyAllowedTenants=tenant1,tenant2,";
+
+      const connectionString = new DurableTaskAzureManagedConnectionString(connectionStringWithTrailingComma);
+      const tenants = connectionString.getAdditionallyAllowedTenants();
+
+      expect(tenants).toEqual(["tenant1", "tenant2"]);
+    });
+
+    it("should handle wildcard tenant value", () => {
+      const connectionStringWithWildcard =
+        VALID_CONNECTION_STRING + ";AdditionallyAllowedTenants=*";
+
+      const connectionString = new DurableTaskAzureManagedConnectionString(connectionStringWithWildcard);
+      const tenants = connectionString.getAdditionallyAllowedTenants();
+
+      expect(tenants).toEqual(["*"]);
+    });
   });
 
   describe("getClientId", () => {


### PR DESCRIPTION
## Summary

- Trim whitespace around comma-separated additional tenant IDs.
- Ignore empty tenant entries caused by trailing or repeated commas.
- Add connection string parsing coverage.

Fixes #211

## Testing

- `npm test -w @microsoft/durabletask-js-azuremanaged -- --runTestsByPath test/unit/connection-string.spec.ts`
- `npm run build:azuremanaged`