### PR TITLE
fix: cancel pending timers on continue-as-new in InMemoryOrchestrationBackend

### DIFF
--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -596,6 +596,11 @@ export class InMemoryOrchestrationBackend {
       const newInput = completeAction.getResult()?.getValue();
       const carryoverEvents = completeAction.getCarryovereventsList();
 
+      // Cancel timers still pending from the previous iteration. Their timer IDs are
+      // sequence numbers that restart at 1 in the new iteration, so a leaked timer
+      // would fire a TimerFired event that completes an unrelated task.
+      this.cancelInstanceTimers(instance.instanceId);
+
       // Reset instance state
       instance.history = [];
       instance.input = newInput;

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -987,4 +987,44 @@ describe("In-Memory Backend", () => {
     backend.reset();
     await longWaitPromise.catch(() => {}); // Ignore the reset rejection
   });
+
+  it("should cancel pending timers on continue-as-new", async () => {
+    // Timer IDs are per-execution sequence numbers that restart at 1 after
+    // continue-as-new. A timer left pending from iteration 1 therefore fires a
+    // TimerFired event whose ID collides with iteration 2's first task, completing
+    // it long before it is due. Iteration 1's timer is deliberately short and
+    // iteration 2's is long, so a leak shows up as an early completion.
+    const staleTimerSeconds = 0.05;
+    const iteration2TimerSeconds = 1.5;
+    let iteration2TimerFired = false;
+
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext, input: number): any {
+      if (input === 1) {
+        // Created but never awaited, then abandoned by continue-as-new.
+        ctx.createTimer(staleTimerSeconds);
+        ctx.continueAsNew(2, false);
+      } else {
+        yield ctx.createTimer(iteration2TimerSeconds);
+        iteration2TimerFired = true;
+        return "done";
+      }
+    };
+
+    worker.addOrchestrator(orchestrator);
+    await worker.start();
+
+    const startedAt = Date.now();
+    const id = await client.scheduleNewOrchestration(orchestrator, 1);
+    const state = await client.waitForOrchestrationCompletion(id, true, 10);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(state).toBeDefined();
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toEqual(JSON.stringify("done"));
+    expect(iteration2TimerFired).toBe(true);
+
+    // Without the cancellation, the stale 50ms timer completes iteration 2's timer
+    // almost immediately. The margin is deliberately wide to stay reliable in CI.
+    expect(elapsedMs).toBeGreaterThan(1000);
+  });
 });


### PR DESCRIPTION
Fixes #207.

## The bug

`InMemoryOrchestrationBackend`'s continue-as-new handler resets instance history but never
cancels the timers still pending from the previous iteration.

Timer IDs are **per-execution sequence numbers that restart at 1** after continue-as-new. So a
timer abandoned by iteration 1 keeps its `setTimeout` alive and later fires a `TimerFired`
event whose ID collides with iteration 2's first task — completing it long before it is due.

## The fix

Call `this.cancelInstanceTimers(instance.instanceId)` before resetting instance state. The
helper already exists and is used elsewhere in the class; continue-as-new was simply missing it.

## Validation — verified against current `main`

| | Elapsed | Result |
|---|---|---|
| Without the fix | **58 ms** | FAIL — `expect(elapsedMs).toBeGreaterThan(1000)` got `58` |
| With the fix | **1562 ms** | pass |

Iteration 2 asks for a 1.5 s timer. Without the fix it finishes in 58 ms, because iteration 1's
abandoned 50 ms timer fires and satisfies it. That 27x gap is the bug.

Full validation: build 0, lint 0, **1177/1177 tests across 67 suites**.

## Note for reviewers — the test was rewritten, and why

The original test on this branch could not fail. It used:

```typescript
ctx.createTimer(60);       // iteration 1 stale timer — 60 SECONDS
...
yield ctx.createTimer(0.05); // iteration 2 real timer — 50ms
```

The stale timer was **longer** than the entire test, so it could never fire in time to cause the
collision, and the test passed identically with and without the fix. The durations needed to be
inverted.

This version uses a **50 ms stale** timer against a **1.5 s real** timer and asserts on elapsed
wall time, so a leak shows up as an early completion. The 1000 ms threshold leaves a wide margin
for CI jitter.

## Note on the rebase

This branch was rebased onto current `main`. The rebase could not be done mechanically: the test
rewrite lived in a merge commit, which `git rebase` drops, so replaying the original commit alone
would have silently restored the broken 60 s test. The change was re-applied onto current `main`
and re-verified from scratch with the numbers above.