### PR TITLE
fix: remove stale waiter in waitForState timeout handler

### DIFF
--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -429,31 +429,48 @@ export class InMemoryOrchestrationBackend {
     return new Promise((resolve, reject) => {
       // When timeoutMs is 0, no timeout is applied — the waiter will only be
       // resolved by a matching state change or rejected by reset().
+      // `waiter` is declared before the timer so the timeout callback can find it by
+      // object identity; the waiter reads `timer` only when invoked, by which point
+      // it has been assigned.
       let timer: ReturnType<typeof setTimeout> | undefined;
-      if (timeoutMs > 0) {
-        timer = setTimeout(() => {
-          const waiters = this.stateWaiters.get(instanceId);
-          if (waiters) {
-            const index = waiters.findIndex((w) => w.resolve === resolve);
-            if (index >= 0) {
-              waiters.splice(index, 1);
-            }
-          }
-          reject(new Error(`Timeout waiting for orchestration '${instanceId}'`));
-        }, timeoutMs);
-      }
 
       const waiter: StateWaiter = {
         resolve: (result) => {
-          if (timer !== undefined) clearTimeout(timer);
+          if (timer !== undefined) {
+            clearTimeout(timer);
+            this.pendingTimers.delete(timer);
+          }
           resolve(result);
         },
         reject: (error) => {
-          if (timer !== undefined) clearTimeout(timer);
+          if (timer !== undefined) {
+            clearTimeout(timer);
+            this.pendingTimers.delete(timer);
+          }
           reject(error);
         },
         predicate,
       };
+
+      if (timeoutMs > 0) {
+        timer = setTimeout(() => {
+          if (timer !== undefined) {
+            this.pendingTimers.delete(timer);
+          }
+          const waiters = this.stateWaiters.get(instanceId);
+          if (waiters) {
+            const index = waiters.indexOf(waiter);
+            if (index >= 0) {
+              waiters.splice(index, 1);
+            }
+            if (waiters.length === 0) {
+              this.stateWaiters.delete(instanceId);
+            }
+          }
+          reject(new Error(`Timeout waiting for orchestration '${instanceId}'`));
+        }, timeoutMs);
+        this.pendingTimers.add(timer);
+      }
 
       let waiters = this.stateWaiters.get(instanceId);
       if (!waiters) {

--- a/packages/durabletask-js/test/in-memory-backend.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend.spec.ts
@@ -933,4 +933,58 @@ describe("In-Memory Backend", () => {
       expect(backend.toClientStatus(suspendedInstance!.status)).toEqual(OrchestrationStatus.SUSPENDED);
     });
   });
+
+  it("should clean up stale waiters after waitForState timeout", async () => {
+    const instanceId = "timeout-cleanup-test";
+    backend.createInstance(instanceId, "testOrch");
+
+    // Call waitForState with a predicate that will never match and a short timeout
+    await expect(
+      backend.waitForState(
+        instanceId,
+        () => false, // Will never match
+        50, // 50ms timeout
+      ),
+    ).rejects.toThrow("Timeout waiting for orchestration");
+
+    // After the timeout, the stale waiter should be cleaned up.
+    // Access internal stateWaiters to verify the waiter was removed.
+    const stateWaitersMap = (backend as any).stateWaiters as Map<string, any[]>;
+
+    // The timed-out waiter should have been removed, and since it was the only
+    // waiter, the instance entry should be removed from the map entirely.
+    expect(stateWaitersMap.has(instanceId)).toBe(false);
+  });
+
+  it("should remove only the timed-out waiter when multiple waiters exist", async () => {
+    const instanceId = "multi-waiter-timeout-test";
+    backend.createInstance(instanceId, "testOrch");
+
+    // Start a waiter with a long timeout (won't time out during the test)
+    const longWaitPromise = backend.waitForState(
+      instanceId,
+      () => false, // Never matches
+      60000, // 60 second timeout — won't fire
+    );
+
+    // Start a waiter with a very short timeout
+    await expect(
+      backend.waitForState(
+        instanceId,
+        () => false, // Never matches
+        50, // 50ms timeout
+      ),
+    ).rejects.toThrow("Timeout waiting for orchestration");
+
+    // After the short timeout, only the long-lived waiter should remain
+    const stateWaitersMap = (backend as any).stateWaiters as Map<string, any[]>;
+    const waiters = stateWaitersMap.get(instanceId);
+
+    expect(waiters).toBeDefined();
+    expect(waiters!.length).toBe(1);
+
+    // Clean up: reset to clear the remaining waiter and its timer
+    backend.reset();
+    await longWaitPromise.catch(() => {}); // Ignore the reset rejection
+  });
 });


### PR DESCRIPTION
Fixes #201.

## The bug

`waitForState()`'s timeout handler tried to remove its own waiter with
`waiters.findIndex((w) => w.resolve === resolve)`. But `w.resolve` is a **wrapper closure**
(`(result) => { clearTimeout(timer); resolve(result); }`), not the Promise's original
`resolve`. Two different function objects, so `findIndex` always returned `-1` and the
`splice` was dead code.

Root cause is a circular dependency: the waiter needs `timer` (to `clearTimeout`), and the
timer callback needs `waiter` (to remove it). The original code declared `timer` first, so
its callback had no `waiter` in scope and fell back to comparing `resolve` — which never
matches.

Verified against unpatched `main`:

```
stateWaiters still has key      : true    (should be gone)
waiters array length            : 1       (should be 0)
after 5 timeouts, waiters       : 5       (unbounded accumulation)
stale predicate re-evaluated    : true    (notifyWaiters keeps running dead predicates)
```

No data corruption — resolving an already-rejected Promise is a no-op — but the waiter and
its closure leak, and `notifyWaiters()` keeps evaluating dead predicates until `reset()`.

## The fix

Declare `waiter` **before** the timer. The wrapper reads `timer` only when invoked, by which
point it has been assigned, so the circular dependency dissolves and the timeout callback can
use object identity:

- `waiters.indexOf(waiter)` instead of the broken `findIndex` reference comparison
- track the timeout timer in `pendingTimers`, and remove it on resolve / reject / timeout
- delete the `stateWaiters` map entry when its last waiter is removed

## Validation

The two new tests fail on unpatched `main`:

| Test | Unpatched `main` | With fix |
|---|---|---|
| `should clean up stale waiters after waitForState timeout` | FAIL — `Expected: false, Received: true` | pass |
| `should remove only the timed-out waiter when multiple waiters exist` | crashes the Node process | pass |

The crash is a real consequence: the assertion fails, so the test's own `reset()` + `.catch()`
cleanup never runs, leaving an unhandled `Backend was reset` rejection.

With the fix: build 0, lint 0, **1178/1178 tests across 67 suites**.

## Note for reviewers — rebase and conflict resolution

This branch was rebased onto current `main` (it predated `executionId` on
`OrchestrationInstance` and no longer compiled against it).

The rebase conflicted with the `timeoutMs === 0` "wait indefinitely" feature that landed on
`main` after this branch was cut. **Taking either side wholesale would have been wrong** — this
branch created the timer unconditionally, which with `timeoutMs = 0` would fire a `setTimeout(…, 0)`
immediately and break that feature. The resolution keeps `main`'s `if (timeoutMs > 0)` guard and
the `timer: … | undefined` type, and applies the fix inside it.

Both `timeoutMs = 0` tests still pass:

```
√ waitForState with zero timeout should wait indefinitely until state matches
√ waitForState with zero timeout should be rejected on reset
√ should clean up stale waiters after waitForState timeout
√ should remove only the timed-out waiter when multiple waiters exist
```

## One correction to #201

The issue lists a fourth impact:

> Timer leak: The `waitForState` timeout timer is not tracked in `pendingTimers`, so it is not
> cleaned up by `reset()`.

That is **not accurate**. `reset()` iterates `stateWaiters` and calls `waiter.reject(...)`, which
is the wrapper that already calls `clearTimeout(timer)`:

```
clearTimeout calls on reset : 1
timer cleared by reset?     : true
```

Adding the timer to `pendingTimers` is defensive bookkeeping, not a leak fix. The other three
impacts in the issue are accurate.