### PR TITLE
docs(durable-functions): mark v3 entity-lock API as won't-restore (#317)

### DIFF
--- a/packages/azure-functions-durable/README.md
+++ b/packages/azure-functions-durable/README.md
@@ -42,8 +42,11 @@ changed:
   `context.df.isLocked()` and the `DurableLock` / `LockState` / `LockingRulesViolationError` exports
   are removed. Acquire locks with the core `context.entities.lockEntities(...entityIds)` (returns a
   `LockHandle` — call `release()`, ideally in a `finally`) and query with
-  `context.entities.isInCriticalSection()`. Restoring the v3 `df.lock` / `isLocked` surface is tracked
-  in [#317](https://github.com/microsoft/durabletask-js/issues/317).
+  `context.entities.isInCriticalSection()`. This is the permanent, supported API — the v3 `df.lock` /
+  `isLocked` surface (and the `DurableLock` / `LockState` / `LockingRulesViolationError` types) will
+  **not** be restored; use the core `context.entities.*` lock API instead. See
+  [#317](https://github.com/microsoft/durabletask-js/issues/317) for the cross-SDK rationale (the
+  Python SDK ships only this core-native lock API and never exposed a `df.lock` / `is_locked` surface).
 - **`context.df.callHttp(...)` now throws.** v3 ran durable HTTP as a host-managed activity; the
   consolidated gRPC backend has no equivalent primitive. Implement an HTTP activity in your app and
   call it from the orchestrator. Restoring `callHttp` as a worker-side durable activity is tracked in


### PR DESCRIPTION
Documents the resolution of #317 as **won''t-do**: keep the core-native entity-lock migration and do **not** restore the v3 `df.lock` / `isLocked` surface.

This is a docs-only change. It flips the one-sentence note in the package README''s "Migrating from durable-functions v3" section (the "Entity locking / critical sections moved to the core context." bullet) from "restoring the v3 surface is tracked in #317" to a final "will not be restored" decision, and points readers to the supported core `context.entities.*` lock API.

Rationale (recorded on #317): the Python SDK ships only the core-native lock API and its classic Functions SDK never exposed `df.lock` / `is_locked`, so there is no cross-SDK compat surface to mirror; JS was the outlier because v3 uniquely exposed it, and reviving the v3 shape would require an engine-level `Task.map` (determinism-sensitive).

No code, CHANGELOG, or test changes - README.md only. See #317 for the full rationale (issue is being closed manually).
