### PR TITLE
feat(testing): implement entity support in the in-memory backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### New
 
+- Implement entity support in the in-memory testing backend ([#341](https://github.com/microsoft/durabletask-js/pull/341))
+
 ### Fixes
 
 

--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -491,7 +491,7 @@ export class InMemoryOrchestrationBackend {
     }
 
     const parent = this.instances.get(parentInstanceId);
-    if (!parent) {
+    if (!parent || parent.executionId !== called.getParentexecutionid()?.getValue()) {
       return;
     }
 

--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -50,8 +50,12 @@ export interface EntityState {
   instanceId: string;
   serializedState?: string;
   lastModifiedAt: Date;
-  /** Critical section ID currently holding the lock, if any. */
+  /** Orchestration instance currently holding the lock, if any. */
   lockedBy?: string;
+  /** Execution of the orchestration that owns the current critical section. */
+  lockOwnerExecutionId?: string;
+  /** Critical section ID used to correlate the matching unlock action. */
+  lockCriticalSectionId?: string;
   /** Operations queued but not yet dispatched to a worker. */
   pendingOperations: pb.HistoryEvent[];
   /** Operations handed to a worker and awaiting a batch result. */
@@ -65,8 +69,17 @@ export interface EntityState {
 interface PendingLockRequest {
   criticalSectionId: string;
   parentInstanceId: string;
+  parentExecutionId: string;
   lockSet: string[];
+  sequenceNumber: number;
 }
+
+interface RewindSnapshotEntry {
+  executionId: string;
+  completionToken: number;
+}
+
+type RewindSnapshot = Map<string, RewindSnapshotEntry>;
 
 /**
  * Entity work item that needs to be executed.
@@ -108,11 +121,14 @@ export class InMemoryOrchestrationBackend {
   private readonly entityQueue: string[] = [];
   private readonly entityQueueSet: Set<string> = new Set();
   private readonly entityInFlight: Set<string> = new Set();
+  private readonly entityOperationSequence: WeakMap<pb.HistoryEvent, number> = new WeakMap();
   private pendingLockRequests: PendingLockRequest[] = [];
   private readonly stateWaiters: Map<string, StateWaiter[]> = new Map();
   private readonly pendingTimers: Set<ReturnType<typeof setTimeout>> = new Set();
   private readonly instanceTimers: Map<string, Set<ReturnType<typeof setTimeout>>> = new Map();
+  private readonly rewindSnapshots: Map<string, RewindSnapshot> = new Map();
   private nextCompletionToken: number = 1;
+  private nextEntityMessageSequence: number = 1;
   private readonly maxHistorySize: number;
 
   /**
@@ -295,6 +311,8 @@ export class InMemoryOrchestrationBackend {
       return false;
     }
 
+    this.cleanupLocksForExecution(instance.instanceId, instance.executionId);
+    this.clearRewindSnapshot(instanceId);
     this.instances.delete(instanceId);
     this.orchestrationQueueSet.delete(instanceId);
     const queueIndex = this.orchestrationQueue.indexOf(instanceId);
@@ -330,7 +348,9 @@ export class InMemoryOrchestrationBackend {
       throw new Error(`Orchestration instance '${instanceId}' is not in a failed state`);
     }
 
-    this.prepareRewind(instance, reason);
+    const snapshot: RewindSnapshot = new Map();
+    this.validateRewindLockState(instance, snapshot);
+    this.prepareRewind(instance, reason, snapshot);
     this.notifyWaiters(instanceId);
   }
 
@@ -382,9 +402,23 @@ export class InMemoryOrchestrationBackend {
         continue;
       }
 
+      const dispatchableOperations: pb.HistoryEvent[] = [];
+      const blockedOperations: pb.HistoryEvent[] = [];
+      for (const operation of entity.pendingOperations) {
+        if (this.canDispatchEntityOperation(entity, operation)) {
+          dispatchableOperations.push(operation);
+        } else {
+          blockedOperations.push(operation);
+        }
+      }
+
+      if (dispatchableOperations.length === 0) {
+        continue;
+      }
+
       this.entityInFlight.add(entityId);
-      entity.dispatchedOperations = entity.pendingOperations.slice();
-      entity.pendingOperations.length = 0;
+      entity.dispatchedOperations = dispatchableOperations;
+      entity.pendingOperations = blockedOperations;
 
       workItem = {
         instanceId: entity.instanceId,
@@ -431,9 +465,12 @@ export class InMemoryOrchestrationBackend {
       this.processEntityAction(action);
     }
 
+    // An entity that was busy when a lock was requested may now be available.
+    this.tryGrantPendingLocks();
+
     // A batch may have produced signals for this same entity, or the entity may have
     // been signalled while its batch was running.
-    if (entity.pendingOperations.length > 0) {
+    if (entity.pendingOperations.some((operation) => this.canDispatchEntityOperation(entity, operation))) {
       this.enqueueEntity(instanceId);
     }
   }
@@ -695,6 +732,7 @@ export class InMemoryOrchestrationBackend {
     this.entityQueueSet.clear();
     this.entityInFlight.clear();
     this.pendingLockRequests = [];
+    this.nextEntityMessageSequence = 1;
     for (const waiters of this.stateWaiters.values()) {
       for (const waiter of waiters) {
         waiter.reject(new Error("Backend was reset"));
@@ -706,6 +744,7 @@ export class InMemoryOrchestrationBackend {
     }
     this.pendingTimers.clear();
     this.instanceTimers.clear();
+    this.rewindSnapshots.clear();
   }
 
   /**
@@ -786,6 +825,11 @@ export class InMemoryOrchestrationBackend {
     completeAction: pb.CompleteOrchestrationAction,
   ): void {
     const status = completeAction.getOrchestrationstatus();
+    if (this.isTerminalStatus(status) || status === pb.OrchestrationStatus.ORCHESTRATION_STATUS_CONTINUED_AS_NEW) {
+      this.cleanupLocksForExecution(instance.instanceId, instance.executionId);
+      this.clearRewindSnapshot(instance.instanceId);
+    }
+
     instance.status = status;
     instance.output = completeAction.getResult()?.getValue();
     // Use an explicit presence check: a protobuf singular message accessor may materialize an
@@ -958,7 +1002,11 @@ export class InMemoryOrchestrationBackend {
       });
   }
 
-  private prepareRewind(instance: OrchestrationInstance, reason?: string): void {
+  private prepareRewind(
+    instance: OrchestrationInstance,
+    reason?: string,
+    snapshot?: RewindSnapshot,
+  ): void {
     // Reset instance state so it can be re-processed.
     instance.status = pb.OrchestrationStatus.ORCHESTRATION_STATUS_RUNNING;
     instance.output = undefined;
@@ -974,6 +1022,14 @@ export class InMemoryOrchestrationBackend {
 
     // Refresh the completion token and enqueue.
     instance.completionToken = this.nextCompletionToken++;
+    if (snapshot) {
+      const expected = snapshot.get(instance.instanceId);
+      if (!expected) {
+        throw new Error(`Cannot prepare unvalidated orchestration '${instance.instanceId}' for rewind`);
+      }
+      expected.completionToken = instance.completionToken;
+      this.rewindSnapshots.set(instance.instanceId, snapshot);
+    }
     this.enqueueOrchestration(instance.instanceId);
   }
 
@@ -981,10 +1037,33 @@ export class InMemoryOrchestrationBackend {
     instance: OrchestrationInstance,
     rewindAction: pb.RewindOrchestrationAction,
   ): void {
+    const snapshot = this.rewindSnapshots.get(instance.instanceId);
+    const expectedInstance = snapshot?.get(instance.instanceId);
+    if (
+      !snapshot ||
+      !expectedInstance ||
+      expectedInstance.executionId !== instance.executionId ||
+      expectedInstance.completionToken !== instance.completionToken
+    ) {
+      throw new Error(`Cannot apply stale rewind for orchestration '${instance.instanceId}'`);
+    }
+
     const newHistory = rewindAction.getNewhistoryList();
+    const executionId = newHistory
+      .find((event) => event.hasExecutionstarted())
+      ?.getExecutionstarted()
+      ?.getOrchestrationinstance()
+      ?.getExecutionid()
+      ?.getValue();
+    if (!executionId) {
+      throw new Error(
+        `Cannot apply rewind for orchestration '${instance.instanceId}': the rewritten history has no execution ID`,
+      );
+    }
 
     // Replace the history with the SDK-computed clean version.
     instance.history = newHistory;
+    instance.executionId = executionId;
     instance.status = pb.OrchestrationStatus.ORCHESTRATION_STATUS_RUNNING;
     instance.output = undefined;
     instance.failureDetails = undefined;
@@ -1034,7 +1113,13 @@ export class InMemoryOrchestrationBackend {
           taskScheduledId: taskId,
         });
       } else if (subInstance.status === pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED) {
-        this.prepareRewind(subInstance, reason);
+        const expectedSubInstance = snapshot.get(subInstanceId);
+        if (
+          expectedSubInstance?.executionId === subInstance.executionId &&
+          expectedSubInstance.completionToken === subInstance.completionToken
+        ) {
+          this.prepareRewind(subInstance, reason, snapshot);
+        }
       }
       this.watchSubOrchestration(instance.instanceId, subInstanceId, taskId);
     }
@@ -1046,6 +1131,7 @@ export class InMemoryOrchestrationBackend {
     // executionCompleted is no longer in the history.
     instance.pendingEvents = [pbh.newOrchestratorStartedEvent(new Date())];
     instance.completionToken = this.nextCompletionToken++;
+    this.clearRewindSnapshot(instance.instanceId);
     this.enqueueOrchestration(instance.instanceId);
   }
 
@@ -1107,7 +1193,9 @@ export class InMemoryOrchestrationBackend {
           this.tryGrantLock({
             criticalSectionId: lockRequested.getCriticalsectionid(),
             parentInstanceId: parentId,
+            parentExecutionId: instance.executionId,
             lockSet: lockRequested.getLocksetList().slice(),
+            sequenceNumber: this.nextEntityMessageSequence++,
           });
         }
         break;
@@ -1117,10 +1205,21 @@ export class InMemoryOrchestrationBackend {
         this.appendEntityHistoryEvent(instance, actionId, (e) => e.setEntityunlocksent(unlock));
 
         const targetId = unlock.getTargetinstanceid()?.getValue();
+        const parentId = unlock.getParentinstanceid()?.getValue();
         if (targetId) {
           const entity = this.entities.get(targetId);
-          if (entity && entity.lockedBy === unlock.getCriticalsectionid()) {
+          if (
+            entity &&
+            entity.lockCriticalSectionId === unlock.getCriticalsectionid() &&
+            entity.lockedBy === parentId &&
+            entity.lockOwnerExecutionId === instance.executionId
+          ) {
             entity.lockedBy = undefined;
+            entity.lockOwnerExecutionId = undefined;
+            entity.lockCriticalSectionId = undefined;
+            if (entity.pendingOperations.length > 0) {
+              this.enqueueEntity(targetId);
+            }
           }
         }
 
@@ -1172,6 +1271,7 @@ export class InMemoryOrchestrationBackend {
 
   private queueEntityOperation(entityId: string, event: pb.HistoryEvent): void {
     const entity = this.getOrCreateEntity(entityId);
+    this.entityOperationSequence.set(event, this.nextEntityMessageSequence++);
     entity.pendingOperations.push(event);
     this.enqueueEntity(entityId);
   }
@@ -1181,6 +1281,39 @@ export class InMemoryOrchestrationBackend {
       this.entityQueue.push(entityId);
       this.entityQueueSet.add(entityId);
     }
+  }
+
+  private canDispatchEntityOperation(entity: EntityState, operation: pb.HistoryEvent): boolean {
+    if (entity.lockedBy !== undefined) {
+      const called = operation.getEntityoperationcalled();
+      return (
+        called?.getParentinstanceid()?.getValue() === entity.lockedBy &&
+        called?.getParentexecutionid()?.getValue() === entity.lockOwnerExecutionId
+      );
+    }
+
+    const lockBarrier = this.getNextLockBarrier(entity.instanceId);
+    if (lockBarrier === undefined) {
+      return true;
+    }
+
+    const operationSequence = this.entityOperationSequence.get(operation);
+    return operationSequence !== undefined && operationSequence < lockBarrier;
+  }
+
+  private getNextLockBarrier(entityId: string): number | undefined {
+    let barrier: number | undefined;
+    for (const pending of this.pendingLockRequests) {
+      if (pending.lockSet.includes(entityId) && (barrier === undefined || pending.sequenceNumber < barrier)) {
+        barrier = pending.sequenceNumber;
+      }
+    }
+    return barrier;
+  }
+
+  private operationPrecedesLock(operation: pb.HistoryEvent, pending: PendingLockRequest): boolean {
+    const operationSequence = this.entityOperationSequence.get(operation);
+    return operationSequence === undefined || operationSequence < pending.sequenceNumber;
   }
 
   /**
@@ -1208,21 +1341,44 @@ export class InMemoryOrchestrationBackend {
   }
 
   private canGrantLock(pending: PendingLockRequest): boolean {
-    return !pending.lockSet.some((entityId) => this.entities.get(entityId)?.lockedBy !== undefined);
+    return !pending.lockSet.some((entityId) => {
+      const entity = this.entities.get(entityId);
+      return (
+        entity?.lockedBy !== undefined ||
+        this.entityInFlight.has(entityId) ||
+        entity?.pendingOperations.some((operation) => this.operationPrecedesLock(operation, pending))
+      );
+    });
+  }
+
+  private hasEarlierOverlappingLockRequest(pending: PendingLockRequest): boolean {
+    const lockSet = new Set(pending.lockSet);
+    return this.pendingLockRequests.some(
+      (earlier) =>
+        earlier.sequenceNumber < pending.sequenceNumber &&
+        this.getActiveLockRequestParent(earlier) !== undefined &&
+        earlier.lockSet.some((entityId) => lockSet.has(entityId)),
+    );
+  }
+
+  private getActiveLockRequestParent(pending: PendingLockRequest): OrchestrationInstance | undefined {
+    const parent = this.instances.get(pending.parentInstanceId);
+    if (!parent || parent.executionId !== pending.parentExecutionId || this.isTerminalStatus(parent.status)) {
+      return undefined;
+    }
+    return parent;
   }
 
   /**
    * Grants a lock to every entity in the lock set and notifies the parent orchestration.
    * Assumes availability was already verified via {@link canGrantLock}.
    */
-  private grantLock(pending: PendingLockRequest): void {
+  private grantLock(pending: PendingLockRequest, parent: OrchestrationInstance): void {
     for (const entityId of pending.lockSet) {
-      this.getOrCreateEntity(entityId).lockedBy = pending.criticalSectionId;
-    }
-
-    const parent = this.instances.get(pending.parentInstanceId);
-    if (!parent) {
-      return;
+      const entity = this.getOrCreateEntity(entityId);
+      entity.lockedBy = pending.parentInstanceId;
+      entity.lockOwnerExecutionId = pending.parentExecutionId;
+      entity.lockCriticalSectionId = pending.criticalSectionId;
     }
 
     const granted = new pb.EntityLockGrantedEvent();
@@ -1239,23 +1395,153 @@ export class InMemoryOrchestrationBackend {
   }
 
   private tryGrantLock(pending: PendingLockRequest): void {
-    if (!this.canGrantLock(pending)) {
+    const parent = this.getActiveLockRequestParent(pending);
+    if (!parent) {
+      return;
+    }
+
+    if (this.hasEarlierOverlappingLockRequest(pending) || !this.canGrantLock(pending)) {
       this.pendingLockRequests.push(pending);
       return;
     }
-    this.grantLock(pending);
+    this.grantLock(pending, parent);
   }
 
   private tryGrantPendingLocks(): void {
     const stillPending: PendingLockRequest[] = [];
     for (const pending of this.pendingLockRequests) {
-      if (this.canGrantLock(pending)) {
-        this.grantLock(pending);
+      const parent = this.getActiveLockRequestParent(pending);
+      if (!parent) {
+        this.enqueuePendingEntityOperations(pending.lockSet);
+        continue;
+      }
+
+      if (!this.hasEarlierOverlappingLockRequest(pending) && this.canGrantLock(pending)) {
+        this.grantLock(pending, parent);
       } else {
         stillPending.push(pending);
       }
     }
     this.pendingLockRequests = stillPending;
+  }
+
+  private cleanupLocksForExecution(instanceId: string, executionId: string): void {
+    const retainedLockRequests: PendingLockRequest[] = [];
+    for (const pending of this.pendingLockRequests) {
+      if (pending.parentInstanceId === instanceId && pending.parentExecutionId === executionId) {
+        this.enqueuePendingEntityOperations(pending.lockSet);
+      } else {
+        retainedLockRequests.push(pending);
+      }
+    }
+    this.pendingLockRequests = retainedLockRequests;
+
+    for (const [entityId, entity] of this.entities) {
+      if (entity.lockedBy !== instanceId || entity.lockOwnerExecutionId !== executionId) {
+        continue;
+      }
+
+      entity.lockedBy = undefined;
+      entity.lockOwnerExecutionId = undefined;
+      entity.lockCriticalSectionId = undefined;
+      if (entity.pendingOperations.length > 0) {
+        this.enqueueEntity(entityId);
+      }
+    }
+
+    this.tryGrantPendingLocks();
+  }
+
+  private enqueuePendingEntityOperations(entityIds: string[]): void {
+    for (const entityId of entityIds) {
+      if ((this.entities.get(entityId)?.pendingOperations.length ?? 0) > 0) {
+        this.enqueueEntity(entityId);
+      }
+    }
+  }
+
+  private hasUnreleasedEntityLock(history: pb.HistoryEvent[]): boolean {
+    const remainingLockSets = new Map<string, Set<string>>();
+
+    for (const event of history) {
+      const lockRequested = event.getEntitylockrequested();
+      if (lockRequested) {
+        remainingLockSets.set(
+          lockRequested.getCriticalsectionid(),
+          new Set(lockRequested.getLocksetList()),
+        );
+        continue;
+      }
+
+      const unlock = event.getEntityunlocksent();
+      const targetId = unlock?.getTargetinstanceid()?.getValue();
+      if (!unlock || !targetId) {
+        continue;
+      }
+
+      const remaining = remainingLockSets.get(unlock.getCriticalsectionid());
+      if (!remaining) {
+        continue;
+      }
+
+      remaining.delete(targetId);
+      if (remaining.size === 0) {
+        remainingLockSets.delete(unlock.getCriticalsectionid());
+      }
+    }
+
+    return remainingLockSets.size > 0;
+  }
+
+  private validateRewindLockState(
+    instance: OrchestrationInstance,
+    snapshot: RewindSnapshot,
+  ): void {
+    if (snapshot.has(instance.instanceId)) {
+      return;
+    }
+    snapshot.set(instance.instanceId, {
+      executionId: instance.executionId,
+      completionToken: instance.completionToken,
+    });
+
+    if (this.hasUnreleasedEntityLock(instance.history)) {
+      throw new Error(
+        `Cannot rewind an orchestration with an unreleased entity lock: '${instance.instanceId}'`,
+      );
+    }
+
+    const completedSubOrchestrationTaskIds = new Set<number>();
+    const createdSubOrchestrations = new Map<number, string>();
+    for (const event of instance.history) {
+      const created = event.getSuborchestrationinstancecreated();
+      if (created) {
+        createdSubOrchestrations.set(event.getEventid(), created.getInstanceid());
+        continue;
+      }
+
+      const completed = event.getSuborchestrationinstancecompleted();
+      if (completed) {
+        completedSubOrchestrationTaskIds.add(completed.getTaskscheduledid());
+      }
+    }
+
+    for (const [taskId, subInstanceId] of createdSubOrchestrations) {
+      if (completedSubOrchestrationTaskIds.has(taskId)) {
+        continue;
+      }
+
+      const subInstance = this.instances.get(subInstanceId);
+      if (subInstance?.status === pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED) {
+        this.validateRewindLockState(subInstance, snapshot);
+      }
+    }
+  }
+
+  private clearRewindSnapshot(instanceId: string): void {
+    const snapshot = this.rewindSnapshots.get(instanceId);
+    this.rewindSnapshots.delete(instanceId);
+    snapshot?.delete(instanceId);
   }
 
   private processSendEventAction(sendEvent: pb.SendEventAction): void {

--- a/packages/durabletask-js/src/testing/in-memory-backend.ts
+++ b/packages/durabletask-js/src/testing/in-memory-backend.ts
@@ -5,6 +5,7 @@ import * as pb from "../proto/orchestrator_service_pb";
 import * as pbh from "../utils/pb-helper.util";
 import { OrchestrationStatus as ClientOrchestrationStatus } from "../orchestration/enum/orchestration-status.enum";
 import { ParentOrchestrationInstance } from "../types/parent-orchestration-instance.type";
+import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
 import { randomUUID } from "crypto";
 
 /** Mints a fresh per-execution ID (DTFx `Guid.ToString("N")` idiom: 32 hex chars, no dashes). */
@@ -43,6 +44,41 @@ export interface ActivityWorkItem {
 }
 
 /**
+ * Internal entity state stored by the in-memory backend.
+ */
+export interface EntityState {
+  instanceId: string;
+  serializedState?: string;
+  lastModifiedAt: Date;
+  /** Critical section ID currently holding the lock, if any. */
+  lockedBy?: string;
+  /** Operations queued but not yet dispatched to a worker. */
+  pendingOperations: pb.HistoryEvent[];
+  /** Operations handed to a worker and awaiting a batch result. */
+  dispatchedOperations: pb.HistoryEvent[];
+  completionToken: number;
+}
+
+/**
+ * Pending lock request from an orchestration that could not be granted immediately.
+ */
+interface PendingLockRequest {
+  criticalSectionId: string;
+  parentInstanceId: string;
+  lockSet: string[];
+}
+
+/**
+ * Entity work item that needs to be executed.
+ */
+export interface EntityWorkItem {
+  instanceId: string;
+  entityState?: string;
+  operations: pb.HistoryEvent[];
+  completionToken: number;
+}
+
+/**
  * Promise resolver for waiting on orchestration state changes.
  */
 interface StateWaiter {
@@ -68,6 +104,11 @@ export class InMemoryOrchestrationBackend {
   private readonly orchestrationQueue: string[] = [];
   private readonly orchestrationQueueSet: Set<string> = new Set();
   private readonly activityQueue: ActivityWorkItem[] = [];
+  private readonly entities: Map<string, EntityState> = new Map();
+  private readonly entityQueue: string[] = [];
+  private readonly entityQueueSet: Set<string> = new Set();
+  private readonly entityInFlight: Set<string> = new Set();
+  private pendingLockRequests: PendingLockRequest[] = [];
   private readonly stateWaiters: Map<string, StateWaiter[]> = new Map();
   private readonly pendingTimers: Set<ReturnType<typeof setTimeout>> = new Set();
   private readonly instanceTimers: Map<string, Set<ReturnType<typeof setTimeout>>> = new Map();
@@ -317,6 +358,176 @@ export class InMemoryOrchestrationBackend {
   }
 
   /**
+   * Gets the next entity work item to process, if any.
+   *
+   * Drains all operations queued for the entity into a single batch and marks the
+   * entity in-flight so it is not dispatched again until the batch completes.
+   */
+  getNextEntityWorkItem(): EntityWorkItem | undefined {
+    const skipped: string[] = [];
+    let workItem: EntityWorkItem | undefined;
+
+    while (this.entityQueue.length > 0) {
+      const entityId = this.entityQueue.shift()!;
+      this.entityQueueSet.delete(entityId);
+
+      const entity = this.entities.get(entityId);
+      if (!entity || entity.pendingOperations.length === 0) {
+        continue;
+      }
+
+      // Already executing a batch; re-queue so it is picked up after completion.
+      if (this.entityInFlight.has(entityId)) {
+        skipped.push(entityId);
+        continue;
+      }
+
+      this.entityInFlight.add(entityId);
+      entity.dispatchedOperations = entity.pendingOperations.slice();
+      entity.pendingOperations.length = 0;
+
+      workItem = {
+        instanceId: entity.instanceId,
+        entityState: entity.serializedState,
+        operations: entity.dispatchedOperations,
+        completionToken: entity.completionToken,
+      };
+      break;
+    }
+
+    for (const entityId of skipped) {
+      this.enqueueEntity(entityId);
+    }
+
+    return workItem;
+  }
+
+  /**
+   * Completes an entity batch execution: persists the new state, delivers operation
+   * results back to calling orchestrations, and applies entity side-effect actions.
+   */
+  completeEntityTask(instanceId: string, completionToken: number, result: pb.EntityBatchResult): void {
+    const entity = this.entities.get(instanceId);
+    if (!entity || entity.completionToken !== completionToken) {
+      return; // Entity was reset/purged, or this is a stale completion
+    }
+
+    const dispatched = entity.dispatchedOperations;
+
+    entity.serializedState = result.getEntitystate()?.getValue() ?? undefined;
+    entity.lastModifiedAt = new Date();
+    entity.dispatchedOperations = [];
+    entity.completionToken = this.nextCompletionToken++;
+    this.entityInFlight.delete(instanceId);
+
+    // Deliver results to callers. Results are index-aligned with the dispatched
+    // operations because the executor pushes exactly one result per operation.
+    const results = result.getResultsList();
+    for (let i = 0; i < dispatched.length; i++) {
+      this.deliverEntityOperationResult(dispatched[i], results[i]);
+    }
+
+    for (const action of result.getActionsList()) {
+      this.processEntityAction(action);
+    }
+
+    // A batch may have produced signals for this same entity, or the entity may have
+    // been signalled while its batch was running.
+    if (entity.pendingOperations.length > 0) {
+      this.enqueueEntity(instanceId);
+    }
+  }
+
+  /**
+   * Delivers a single entity operation result back to the orchestration that called it.
+   * Signals are fire-and-forget and produce no response.
+   */
+  private deliverEntityOperationResult(operation: pb.HistoryEvent, result?: pb.OperationResult): void {
+    const called = operation.getEntityoperationcalled();
+    if (!called || !result) {
+      return;
+    }
+
+    const parentInstanceId = called.getParentinstanceid()?.getValue();
+    if (!parentInstanceId) {
+      return;
+    }
+
+    const parent = this.instances.get(parentInstanceId);
+    if (!parent) {
+      return;
+    }
+
+    const event = new pb.HistoryEvent();
+    event.setEventid(-1);
+    event.setTimestamp(pbh.newTimestamp(new Date()));
+
+    const success = result.getSuccess();
+    const failure = result.getFailure();
+
+    if (success) {
+      const completed = new pb.EntityOperationCompletedEvent();
+      completed.setRequestid(called.getRequestid());
+      const output = success.getResult();
+      if (output) {
+        completed.setOutput(output);
+      }
+      event.setEntityoperationcompleted(completed);
+    } else if (failure) {
+      const failed = new pb.EntityOperationFailedEvent();
+      failed.setRequestid(called.getRequestid());
+      const details = failure.getFailuredetails();
+      if (details) {
+        failed.setFailuredetails(details);
+      }
+      event.setEntityoperationfailed(failed);
+    } else {
+      return;
+    }
+
+    parent.pendingEvents.push(event);
+    parent.lastUpdatedAt = new Date();
+    this.enqueueOrchestration(parentInstanceId);
+  }
+
+  /**
+   * Applies a side-effect action produced by an entity operation.
+   */
+  private processEntityAction(action: pb.OperationAction): void {
+    const sendSignal = action.getSendsignal();
+    if (sendSignal) {
+      this.signalEntityInternal(sendSignal.getInstanceid(), sendSignal.getName(), sendSignal.getInput()?.getValue());
+      return;
+    }
+
+    const startNew = action.getStartneworchestration();
+    if (startNew) {
+      const instanceId = startNew.getInstanceid() || randomUUID().replace(/-/g, "");
+      if (!this.instances.has(instanceId)) {
+        this.createInstance(instanceId, startNew.getName(), startNew.getInput()?.getValue());
+      }
+    }
+  }
+
+  /**
+   * Signals an entity from outside an orchestration (client-initiated, fire-and-forget).
+   *
+   * @param entityId The entity instance ID, in `@name@key` form.
+   * @param operation The operation name to invoke.
+   * @param input Optional serialized operation input.
+   */
+  signalEntity(entityId: string, operation: string, input?: string): void {
+    this.signalEntityInternal(entityId, operation, input);
+  }
+
+  /**
+   * Gets the current state of an entity, if it exists. Intended for test assertions.
+   */
+  getEntity(instanceId: string): EntityState | undefined {
+    return this.entities.get(instanceId);
+  }
+
+  /**
    * Completes an orchestration execution with the given actions.
    */
   completeOrchestration(
@@ -468,7 +679,7 @@ export class InMemoryOrchestrationBackend {
    * Checks if there are any pending work items.
    */
   hasPendingWork(): boolean {
-    return this.orchestrationQueue.length > 0 || this.activityQueue.length > 0;
+    return this.orchestrationQueue.length > 0 || this.activityQueue.length > 0 || this.entityQueue.length > 0;
   }
 
   /**
@@ -479,6 +690,11 @@ export class InMemoryOrchestrationBackend {
     this.orchestrationQueue.length = 0;
     this.orchestrationQueueSet.clear();
     this.activityQueue.length = 0;
+    this.entities.clear();
+    this.entityQueue.length = 0;
+    this.entityQueueSet.clear();
+    this.entityInFlight.clear();
+    this.pendingLockRequests = [];
     for (const waiters of this.stateWaiters.values()) {
       for (const waiter of waiters) {
         waiter.reject(new Error("Backend was reset"));
@@ -550,6 +766,9 @@ export class InMemoryOrchestrationBackend {
         break;
       case pb.OrchestratorAction.OrchestratoractiontypeCase.SENDEVENT:
         this.processSendEventAction(action.getSendevent()!);
+        break;
+      case pb.OrchestratorAction.OrchestratoractiontypeCase.SENDENTITYMESSAGE:
+        this.processSendEntityMessageAction(instance, action);
         break;
       case pb.OrchestratorAction.OrchestratoractiontypeCase.REWINDORCHESTRATION:
         this.processRewindOrchestrationAction(instance, action.getRewindorchestration()!);
@@ -828,6 +1047,215 @@ export class InMemoryOrchestrationBackend {
     instance.pendingEvents = [pbh.newOrchestratorStartedEvent(new Date())];
     instance.completionToken = this.nextCompletionToken++;
     this.enqueueOrchestration(instance.instanceId);
+  }
+
+  /**
+   * Handles an entity message emitted by an orchestration.
+   *
+   * Mirrors the Python in-memory backend: each outbound message is echoed into the
+   * orchestration history (so replay validation sees the confirmation) and then routed
+   * to the target entity or the lock manager.
+   */
+  private processSendEntityMessageAction(instance: OrchestrationInstance, action: pb.OrchestratorAction): void {
+    const entityMessage = action.getSendentitymessage()!;
+    const actionId = action.getId();
+    const messageTypeCase = pb.SendEntityMessageAction.EntitymessagetypeCase;
+
+    switch (entityMessage.getEntitymessagetypeCase()) {
+      case messageTypeCase.ENTITYOPERATIONSIGNALED: {
+        const signaled = entityMessage.getEntityoperationsignaled()!;
+        this.appendEntityHistoryEvent(instance, actionId, (e) => e.setEntityoperationsignaled(signaled));
+
+        const targetId = signaled.getTargetinstanceid()?.getValue();
+        if (targetId) {
+          const queued = new pb.HistoryEvent();
+          queued.setEventid(-1);
+          queued.setTimestamp(pbh.newTimestamp(new Date()));
+          queued.setEntityoperationsignaled(signaled);
+          this.queueEntityOperation(targetId, queued);
+        }
+        break;
+      }
+      case messageTypeCase.ENTITYOPERATIONCALLED: {
+        const called = entityMessage.getEntityoperationcalled()!;
+        this.appendEntityHistoryEvent(instance, actionId, (e) => e.setEntityoperationcalled(called));
+
+        if (instance.status === pb.OrchestrationStatus.ORCHESTRATION_STATUS_PENDING) {
+          instance.status = pb.OrchestrationStatus.ORCHESTRATION_STATUS_RUNNING;
+        }
+
+        const targetId = called.getTargetinstanceid()?.getValue();
+        if (targetId) {
+          const queued = new pb.HistoryEvent();
+          queued.setEventid(-1);
+          queued.setTimestamp(pbh.newTimestamp(new Date()));
+          queued.setEntityoperationcalled(called);
+          this.queueEntityOperation(targetId, queued);
+        }
+        break;
+      }
+      case messageTypeCase.ENTITYLOCKREQUESTED: {
+        const lockRequested = entityMessage.getEntitylockrequested()!;
+        this.appendEntityHistoryEvent(instance, actionId, (e) => e.setEntitylockrequested(lockRequested));
+
+        if (instance.status === pb.OrchestrationStatus.ORCHESTRATION_STATUS_PENDING) {
+          instance.status = pb.OrchestrationStatus.ORCHESTRATION_STATUS_RUNNING;
+        }
+
+        const parentId = lockRequested.getParentinstanceid()?.getValue();
+        if (parentId) {
+          this.tryGrantLock({
+            criticalSectionId: lockRequested.getCriticalsectionid(),
+            parentInstanceId: parentId,
+            lockSet: lockRequested.getLocksetList().slice(),
+          });
+        }
+        break;
+      }
+      case messageTypeCase.ENTITYUNLOCKSENT: {
+        const unlock = entityMessage.getEntityunlocksent()!;
+        this.appendEntityHistoryEvent(instance, actionId, (e) => e.setEntityunlocksent(unlock));
+
+        const targetId = unlock.getTargetinstanceid()?.getValue();
+        if (targetId) {
+          const entity = this.entities.get(targetId);
+          if (entity && entity.lockedBy === unlock.getCriticalsectionid()) {
+            entity.lockedBy = undefined;
+          }
+        }
+
+        this.tryGrantPendingLocks();
+        break;
+      }
+      default:
+        throw new Error(
+          `Unknown entity message type '${entityMessage.getEntitymessagetypeCase()}' for orchestration ` +
+            `'${instance.instanceId}'. This likely means the in-memory backend needs to be updated to handle ` +
+            `a newly introduced entity message type.`,
+        );
+    }
+  }
+
+  /**
+   * Appends the confirmation event for an outbound entity message to the orchestration history.
+   * The event ID must be the originating action ID so replay validation can match it.
+   */
+  private appendEntityHistoryEvent(
+    instance: OrchestrationInstance,
+    actionId: number,
+    populate: (event: pb.HistoryEvent) => void,
+  ): void {
+    const event = new pb.HistoryEvent();
+    event.setEventid(actionId);
+    event.setTimestamp(pbh.newTimestamp(new Date()));
+    populate(event);
+    instance.history.push(event);
+  }
+
+  /**
+   * Gets (or lazily creates) the state record for an entity.
+   */
+  private getOrCreateEntity(entityId: string): EntityState {
+    let entity = this.entities.get(entityId);
+    if (!entity) {
+      entity = {
+        instanceId: entityId,
+        lastModifiedAt: new Date(),
+        pendingOperations: [],
+        dispatchedOperations: [],
+        completionToken: this.nextCompletionToken++,
+      };
+      this.entities.set(entityId, entity);
+    }
+    return entity;
+  }
+
+  private queueEntityOperation(entityId: string, event: pb.HistoryEvent): void {
+    const entity = this.getOrCreateEntity(entityId);
+    entity.pendingOperations.push(event);
+    this.enqueueEntity(entityId);
+  }
+
+  private enqueueEntity(entityId: string): void {
+    if (!this.entityQueueSet.has(entityId)) {
+      this.entityQueue.push(entityId);
+      this.entityQueueSet.add(entityId);
+    }
+  }
+
+  /**
+   * Signals an entity as a side effect of another entity's operation.
+   */
+  private signalEntityInternal(entityId: string, operation: string, input?: string): void {
+    const signaled = new pb.EntityOperationSignaledEvent();
+    signaled.setRequestid(randomUUID().replace(/-/g, ""));
+    signaled.setOperation(operation);
+    if (input !== undefined) {
+      const value = new StringValue();
+      value.setValue(input);
+      signaled.setInput(value);
+    }
+    const target = new StringValue();
+    target.setValue(entityId);
+    signaled.setTargetinstanceid(target);
+
+    const event = new pb.HistoryEvent();
+    event.setEventid(-1);
+    event.setTimestamp(pbh.newTimestamp(new Date()));
+    event.setEntityoperationsignaled(signaled);
+
+    this.queueEntityOperation(entityId, event);
+  }
+
+  private canGrantLock(pending: PendingLockRequest): boolean {
+    return !pending.lockSet.some((entityId) => this.entities.get(entityId)?.lockedBy !== undefined);
+  }
+
+  /**
+   * Grants a lock to every entity in the lock set and notifies the parent orchestration.
+   * Assumes availability was already verified via {@link canGrantLock}.
+   */
+  private grantLock(pending: PendingLockRequest): void {
+    for (const entityId of pending.lockSet) {
+      this.getOrCreateEntity(entityId).lockedBy = pending.criticalSectionId;
+    }
+
+    const parent = this.instances.get(pending.parentInstanceId);
+    if (!parent) {
+      return;
+    }
+
+    const granted = new pb.EntityLockGrantedEvent();
+    granted.setCriticalsectionid(pending.criticalSectionId);
+
+    const event = new pb.HistoryEvent();
+    event.setEventid(-1);
+    event.setTimestamp(pbh.newTimestamp(new Date()));
+    event.setEntitylockgranted(granted);
+
+    parent.pendingEvents.push(event);
+    parent.lastUpdatedAt = new Date();
+    this.enqueueOrchestration(pending.parentInstanceId);
+  }
+
+  private tryGrantLock(pending: PendingLockRequest): void {
+    if (!this.canGrantLock(pending)) {
+      this.pendingLockRequests.push(pending);
+      return;
+    }
+    this.grantLock(pending);
+  }
+
+  private tryGrantPendingLocks(): void {
+    const stillPending: PendingLockRequest[] = [];
+    for (const pending of this.pendingLockRequests) {
+      if (this.canGrantLock(pending)) {
+        this.grantLock(pending);
+      } else {
+        stillPending.push(pending);
+      }
+    }
+    this.pendingLockRequests = stillPending;
   }
 
   private processSendEventAction(sendEvent: pb.SendEventAction): void {

--- a/packages/durabletask-js/src/testing/test-client.ts
+++ b/packages/durabletask-js/src/testing/test-client.ts
@@ -7,6 +7,8 @@ import { TOrchestrator } from "../types/orchestrator.type";
 import { TInput } from "../types/input.type";
 import { OrchestrationState } from "../orchestration/orchestration-state";
 import { FailureDetails } from "../task/failure-details";
+import { EntityInstanceId } from "../entities/entity-instance-id";
+import { EntityMetadata } from "../entities/entity-metadata";
 import { InMemoryOrchestrationBackend, OrchestrationInstance } from "./in-memory-backend";
 import * as pb from "../proto/orchestrator_service_pb";
 
@@ -138,6 +140,49 @@ export class TestOrchestrationClient {
    */
   async rewindOrchestration(instanceId: string, reason?: string): Promise<void> {
     this.backend.rewindInstance(instanceId, reason);
+  }
+
+  /**
+   * Signals an entity with a one-way (fire-and-forget) operation.
+   *
+   * @param id The entity to signal.
+   * @param operationName The name of the operation to invoke.
+   * @param input Optional operation input. Serialized as JSON.
+   */
+  async signalEntity(id: EntityInstanceId, operationName: string, input?: unknown): Promise<void> {
+    this.backend.signalEntity(
+      id.toString(),
+      operationName,
+      input === undefined ? undefined : JSON.stringify(input),
+    );
+  }
+
+  /**
+   * Gets the metadata of an entity, or undefined if the entity does not exist.
+   *
+   * @param id The entity to look up.
+   * @param includeState Whether to deserialize and include the entity state.
+   */
+  async getEntity<T = unknown>(
+    id: EntityInstanceId,
+    includeState: boolean = true,
+  ): Promise<EntityMetadata<T> | undefined> {
+    const entity = this.backend.getEntity(id.toString());
+    if (!entity) {
+      return undefined;
+    }
+
+    return {
+      id,
+      lastModifiedTime: entity.lastModifiedAt,
+      backlogQueueSize: entity.pendingOperations.length,
+      lockedBy: entity.lockedBy,
+      includesState: includeState,
+      state:
+        includeState && entity.serializedState !== undefined
+          ? (JSON.parse(entity.serializedState) as T)
+          : undefined,
+    };
   }
 
   /**

--- a/packages/durabletask-js/src/testing/test-worker.ts
+++ b/packages/durabletask-js/src/testing/test-worker.ts
@@ -4,11 +4,20 @@
 import { Registry } from "../worker/registry";
 import { OrchestrationExecutor } from "../worker/orchestration-executor";
 import { ActivityExecutor } from "../worker/activity-executor";
+import { TaskEntityShim } from "../worker/entity-executor";
+import { EntityInstanceId } from "../entities/entity-instance-id";
+import { EntityFactory } from "../entities/task-entity";
 import { TOrchestrator } from "../types/orchestrator.type";
 import { TActivity } from "../types/activity.type";
 import { TInput } from "../types/input.type";
 import { TOutput } from "../types/output.type";
-import { InMemoryOrchestrationBackend, OrchestrationInstance, ActivityWorkItem } from "./in-memory-backend";
+import {
+  InMemoryOrchestrationBackend,
+  OrchestrationInstance,
+  ActivityWorkItem,
+  EntityWorkItem,
+} from "./in-memory-backend";
+import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
 import * as pb from "../proto/orchestrator_service_pb";
 import * as pbh from "../utils/pb-helper.util";
 
@@ -74,6 +83,27 @@ export class TestOrchestrationWorker {
   }
 
   /**
+   * Registers an entity with the worker.
+   */
+  addEntity(factory: EntityFactory): string {
+    if (this.isRunning) {
+      throw new Error("Cannot add entity while worker is running.");
+    }
+    return this.registry.addEntity(factory);
+  }
+
+  /**
+   * Registers a named entity function with the worker.
+   */
+  addNamedEntity(name: string, factory: EntityFactory): string {
+    if (this.isRunning) {
+      throw new Error("Cannot add entity while worker is running.");
+    }
+    this.registry.addNamedEntity(name, factory);
+    return name;
+  }
+
+  /**
    * Starts the worker processing loop.
    */
   async start(): Promise<void> {
@@ -126,6 +156,13 @@ export class TestOrchestrationWorker {
         processedAny = true;
       }
 
+      // Then process entities
+      const entity = this.backend.getNextEntityWorkItem();
+      if (entity) {
+        await this.processEntity(entity);
+        processedAny = true;
+      }
+
       // If nothing was processed, yield to allow other async operations
       if (!processedAny) {
         await this.yieldToEventLoop();
@@ -173,6 +210,95 @@ export class TestOrchestrationWorker {
       const err = error instanceof Error ? error : new Error(String(error));
       this.backend.completeActivity(instanceId, taskId, undefined, err);
     }
+  }
+
+  /**
+   * Processes a single entity work item by executing the batch of queued operations.
+   */
+  private async processEntity(workItem: EntityWorkItem): Promise<void> {
+    const { instanceId, completionToken } = workItem;
+
+    const batchResult = await this.executeEntityBatch(workItem);
+    this.backend.completeEntityTask(instanceId, completionToken, batchResult);
+  }
+
+  /**
+   * Builds an EntityBatchRequest from the work item and runs it through the entity shim.
+   * Any failure is converted into a per-operation failure so callers are never left hanging.
+   */
+  private async executeEntityBatch(workItem: EntityWorkItem): Promise<pb.EntityBatchResult> {
+    const { instanceId, entityState, operations } = workItem;
+
+    try {
+      const entityId = EntityInstanceId.fromString(instanceId);
+      const factory = this.registry.getEntity(entityId.name);
+
+      if (!factory) {
+        return this.createEntityFailureResult(operations, new Error(`No entity task named '${entityId.name}' was found.`));
+      }
+
+      const request = new pb.EntityBatchRequest();
+      request.setInstanceid(instanceId);
+      if (entityState !== undefined) {
+        const state = new StringValue();
+        state.setValue(entityState);
+        request.setEntitystate(state);
+      }
+      request.setOperationsList(operations.map((op) => this.toOperationRequest(op)));
+
+      const shim = new TaskEntityShim(factory(), entityId);
+      return await shim.executeAsync(request);
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      return this.createEntityFailureResult(operations, err);
+    }
+  }
+
+  /**
+   * Converts a queued entity operation history event into the OperationRequest the shim expects.
+   */
+  private toOperationRequest(event: pb.HistoryEvent): pb.OperationRequest {
+    const request = new pb.OperationRequest();
+    const called = event.getEntityoperationcalled();
+    const signaled = event.getEntityoperationsignaled();
+
+    if (called) {
+      request.setOperation(called.getOperation());
+      request.setRequestid(called.getRequestid());
+      const input = called.getInput();
+      if (input) {
+        request.setInput(input);
+      }
+    } else if (signaled) {
+      request.setOperation(signaled.getOperation());
+      request.setRequestid(signaled.getRequestid());
+      const input = signaled.getInput();
+      if (input) {
+        request.setInput(input);
+      }
+    }
+
+    return request;
+  }
+
+  /**
+   * Builds a batch result that fails every operation in the batch with the same error.
+   */
+  private createEntityFailureResult(operations: pb.HistoryEvent[], error: Error): pb.EntityBatchResult {
+    const batchResult = new pb.EntityBatchResult();
+    const failureDetails = pbh.newFailureDetails(error);
+
+    batchResult.setResultsList(
+      operations.map(() => {
+        const failure = new pb.OperationResultFailure();
+        failure.setFailuredetails(failureDetails);
+        const result = new pb.OperationResult();
+        result.setFailure(failure);
+        return result;
+      }),
+    );
+
+    return batchResult;
   }
 
   /**

--- a/packages/durabletask-js/src/testing/test-worker.ts
+++ b/packages/durabletask-js/src/testing/test-worker.ts
@@ -234,7 +234,11 @@ export class TestOrchestrationWorker {
       const factory = this.registry.getEntity(entityId.name);
 
       if (!factory) {
-        return this.createEntityFailureResult(operations, new Error(`No entity task named '${entityId.name}' was found.`));
+        return this.createEntityFailureResult(
+          operations,
+          entityState,
+          new Error(`No entity task named '${entityId.name}' was found.`),
+        );
       }
 
       const request = new pb.EntityBatchRequest();
@@ -250,7 +254,7 @@ export class TestOrchestrationWorker {
       return await shim.executeAsync(request);
     } catch (error: unknown) {
       const err = error instanceof Error ? error : new Error(String(error));
-      return this.createEntityFailureResult(operations, err);
+      return this.createEntityFailureResult(operations, entityState, err);
     }
   }
 
@@ -284,9 +288,19 @@ export class TestOrchestrationWorker {
   /**
    * Builds a batch result that fails every operation in the batch with the same error.
    */
-  private createEntityFailureResult(operations: pb.HistoryEvent[], error: Error): pb.EntityBatchResult {
+  private createEntityFailureResult(
+    operations: pb.HistoryEvent[],
+    entityState: string | undefined,
+    error: Error,
+  ): pb.EntityBatchResult {
     const batchResult = new pb.EntityBatchResult();
     const failureDetails = pbh.newFailureDetails(error);
+
+    if (entityState !== undefined) {
+      const state = new StringValue();
+      state.setValue(entityState);
+      batchResult.setEntitystate(state);
+    }
 
     batchResult.setResultsList(
       operations.map(() => {

--- a/packages/durabletask-js/test/in-memory-backend-entities.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend-entities.spec.ts
@@ -11,6 +11,9 @@ import {
   TaskEntity,
   EntityInstanceId,
 } from "../src";
+import * as pb from "../src/proto/orchestrator_service_pb";
+import * as pbh from "../src/utils/pb-helper.util";
+import { buildRewindResult } from "../src/worker/rewind";
 
 class CounterEntity extends TaskEntity<{ count: number }> {
   add(amount: number): number {
@@ -64,6 +67,7 @@ describe("In-Memory Backend - Entities", () => {
   let worker: TestOrchestrationWorker;
 
   const counterId = new EntityInstanceId("counter", "mykey");
+  const otherCounterId = new EntityInstanceId("counter", "other");
 
   beforeEach(() => {
     backend = new InMemoryOrchestrationBackend();
@@ -222,6 +226,545 @@ describe("In-Memory Backend - Entities", () => {
 
     const released = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy === undefined);
     expect(released).toBe(true);
+  });
+
+  it("should process already queued operations before granting an entity lock", async () => {
+    const lockHolder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      const value = yield ctx.entities.callEntity<number>(counterId, "get");
+      lock.release();
+      return value;
+    };
+
+    worker.addOrchestrator(lockHolder);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+
+    await client.signalEntity(counterId, "add", 3);
+    const holderId = await client.scheduleNewOrchestration(lockHolder);
+    await worker.start();
+
+    const holderState = await client.waitForOrchestrationCompletion(holderId, true, 10);
+
+    expect(holderState?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(holderState?.serializedOutput).toEqual(JSON.stringify(3));
+  });
+
+  it("should defer client signals until an entity lock is released", async () => {
+    const lockHolder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+    };
+
+    worker.addOrchestrator(lockHolder);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const holderId = await client.scheduleNewOrchestration(lockHolder);
+    const locked = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy !== undefined);
+    expect(locked).toBe(true);
+
+    await client.signalEntity(counterId, "add", 5);
+    await client.signalEntity(otherCounterId, "add", 1);
+
+    const otherProcessed = await waitFor(
+      () => backend.getEntity(otherCounterId.toString())?.serializedState !== undefined,
+    );
+    expect(otherProcessed).toBe(true);
+    expect(backend.getEntity(counterId.toString())?.serializedState).toBeUndefined();
+    expect(backend.getEntity(counterId.toString())?.pendingOperations).toHaveLength(1);
+
+    await client.raiseOrchestrationEvent(holderId, "release");
+    await client.waitForOrchestrationCompletion(holderId, true, 10);
+
+    const processedAfterRelease = await waitFor(
+      () => backend.getEntity(counterId.toString())?.serializedState !== undefined,
+    );
+    expect(processedAfterRelease).toBe(true);
+    expect((await client.getEntity<{ count: number }>(counterId))?.state?.count).toEqual(5);
+  });
+
+  it("should defer calls from other orchestrations until an entity lock is released", async () => {
+    const lockHolder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+    };
+    const caller: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      return yield ctx.entities.callEntity<number>(counterId, "add", 7);
+    };
+
+    worker.addOrchestrator(lockHolder);
+    worker.addOrchestrator(caller);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const holderId = await client.scheduleNewOrchestration(lockHolder);
+    const locked = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy !== undefined);
+    expect(locked).toBe(true);
+
+    const callerId = await client.scheduleNewOrchestration(caller);
+    await client.signalEntity(otherCounterId, "add", 1);
+
+    const otherProcessed = await waitFor(
+      () => backend.getEntity(otherCounterId.toString())?.serializedState !== undefined,
+    );
+    expect(otherProcessed).toBe(true);
+    expect(backend.getInstance(callerId)?.output).toBeUndefined();
+    expect(backend.getEntity(counterId.toString())?.serializedState).toBeUndefined();
+    expect(backend.getEntity(counterId.toString())?.pendingOperations).toHaveLength(1);
+
+    await client.raiseOrchestrationEvent(holderId, "release");
+    await client.waitForOrchestrationCompletion(holderId, true, 10);
+    const callerState = await client.waitForOrchestrationCompletion(callerId, true, 10);
+
+    expect(callerState?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(callerState?.serializedOutput).toEqual(JSON.stringify(7));
+  });
+
+  it("should discard stale pending lock requests when their orchestration is purged", async () => {
+    const holder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+    };
+    const waiter: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.lockEntities(counterId);
+      return "acquired";
+    };
+
+    worker.addOrchestrator(holder);
+    worker.addOrchestrator(waiter);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const holderId = await client.scheduleNewOrchestration(holder);
+    const holderLocked = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy !== undefined);
+    expect(holderLocked).toBe(true);
+
+    const waiterId = await client.scheduleNewOrchestration(waiter);
+    await client.waitForOrchestrationStart(waiterId, false, 10);
+    await client.terminateOrchestration(waiterId);
+    await client.waitForOrchestrationCompletion(waiterId, false, 10);
+    expect((await client.purgeOrchestration(waiterId)).deletedInstanceCount).toEqual(1);
+
+    await client.raiseOrchestrationEvent(holderId, "release");
+    await client.waitForOrchestrationCompletion(holderId, false, 10);
+
+    await client.signalEntity(counterId, "add", 5);
+    await client.signalEntity(otherCounterId, "add", 1);
+    const otherProcessed = await waitFor(
+      () => backend.getEntity(otherCounterId.toString())?.serializedState !== undefined,
+    );
+    expect(otherProcessed).toBe(true);
+
+    expect(backend.getEntity(counterId.toString())?.lockedBy).toBeUndefined();
+    expect((await client.getEntity<{ count: number }>(counterId))?.state?.count).toEqual(5);
+  });
+
+  it("should release entity locks when their orchestration terminates", async () => {
+    const holder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("never");
+    };
+
+    worker.addOrchestrator(holder);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const holderId = await client.scheduleNewOrchestration(holder);
+    const locked = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy !== undefined);
+    expect(locked).toBe(true);
+
+    await client.terminateOrchestration(holderId);
+    await client.waitForOrchestrationCompletion(holderId, false, 10);
+
+    await client.signalEntity(counterId, "add", 5);
+    await client.signalEntity(otherCounterId, "add", 1);
+    const otherProcessed = await waitFor(
+      () => backend.getEntity(otherCounterId.toString())?.serializedState !== undefined,
+    );
+    expect(otherProcessed).toBe(true);
+
+    expect(backend.getEntity(counterId.toString())?.lockedBy).toBeUndefined();
+    expect((await client.getEntity<{ count: number }>(counterId))?.state?.count).toEqual(5);
+  });
+
+  it("should match a lock owner by execution ID when an instance ID is reused", async () => {
+    const holder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("never");
+    };
+    const caller: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      return yield ctx.entities.callEntity<number>(counterId, "add", 7);
+    };
+    const reusedInstanceId = "reused-owner";
+
+    worker.addOrchestrator(holder);
+    worker.addOrchestrator(caller);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    await client.scheduleNewOrchestration(holder, undefined, reusedInstanceId);
+    const locked = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy !== undefined);
+    expect(locked).toBe(true);
+    const oldExecutionId = backend.getInstance(reusedInstanceId)!.executionId;
+
+    await client.terminateOrchestration(reusedInstanceId);
+    await client.waitForOrchestrationCompletion(reusedInstanceId, false, 10);
+    expect((await client.purgeOrchestration(reusedInstanceId)).deletedInstanceCount).toEqual(1);
+
+    Object.assign(backend.getEntity(counterId.toString())!, {
+      lockedBy: reusedInstanceId,
+      lockOwnerExecutionId: oldExecutionId,
+      lockCriticalSectionId: "stale-lock",
+    });
+
+    const callerId = await client.scheduleNewOrchestration(caller, undefined, reusedInstanceId);
+    await client.signalEntity(otherCounterId, "add", 1);
+    const otherProcessed = await waitFor(
+      () => backend.getEntity(otherCounterId.toString())?.serializedState !== undefined,
+    );
+    expect(otherProcessed).toBe(true);
+
+    expect(backend.getInstance(callerId)?.executionId).not.toEqual(oldExecutionId);
+    expect(backend.getInstance(callerId)?.output).toBeUndefined();
+    expect(backend.getEntity(counterId.toString())?.serializedState).toBeUndefined();
+  });
+
+  it("should grant overlapping lock requests in request order", async () => {
+    const entityA = new EntityInstanceId("counter", "a");
+    const entityB = new EntityInstanceId("counter", "b");
+
+    const blocker: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(entityB);
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+    };
+    const firstWaiter: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(entityA, entityB);
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+    };
+    const secondWaiter: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(entityA);
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+    };
+
+    worker.addOrchestrator(blocker);
+    worker.addOrchestrator(firstWaiter);
+    worker.addOrchestrator(secondWaiter);
+    await worker.start();
+
+    const blockerId = await client.scheduleNewOrchestration(blocker);
+    const entityBLocked = await waitFor(() => backend.getEntity(entityB.toString())?.lockedBy === blockerId);
+    expect(entityBLocked).toBe(true);
+
+    const firstId = await client.scheduleNewOrchestration(firstWaiter);
+    await client.waitForOrchestrationStart(firstId, false, 10);
+    const secondId = await client.scheduleNewOrchestration(secondWaiter);
+    await client.waitForOrchestrationStart(secondId, false, 10);
+
+    expect(backend.getEntity(entityA.toString())?.lockedBy).toBeUndefined();
+
+    await client.raiseOrchestrationEvent(blockerId, "release");
+    await client.waitForOrchestrationCompletion(blockerId, false, 10);
+    const firstGranted = await waitFor(
+      () =>
+        backend.getEntity(entityA.toString())?.lockedBy === firstId &&
+        backend.getEntity(entityB.toString())?.lockedBy === firstId,
+    );
+    expect(firstGranted).toBe(true);
+
+    await client.raiseOrchestrationEvent(firstId, "release");
+    await client.waitForOrchestrationCompletion(firstId, false, 10);
+    const secondGranted = await waitFor(
+      () => backend.getEntity(entityA.toString())?.lockedBy === secondId,
+    );
+    expect(secondGranted).toBe(true);
+
+    await client.raiseOrchestrationEvent(secondId, "release");
+    await client.waitForOrchestrationCompletion(secondId, false, 10);
+  });
+
+  it("should finish an old owner batch before granting a waiting lock", async () => {
+    let markOperationStarted!: () => void;
+    let releaseOperation!: () => void;
+    const operationStarted = new Promise<void>((resolve) => {
+      markOperationStarted = resolve;
+    });
+    const operationReleased = new Promise<void>((resolve) => {
+      releaseOperation = resolve;
+    });
+
+    class BlockingCounterEntity extends CounterEntity {
+      async block(): Promise<void> {
+        markOperationStarted();
+        await operationReleased;
+      }
+    }
+
+    const holder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("start");
+      yield ctx.entities.callEntity(counterId, "block");
+      lock.release();
+    };
+    const waiter: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+    };
+    const secondWorker = new TestOrchestrationWorker(backend);
+
+    for (const testWorker of [worker, secondWorker]) {
+      testWorker.addOrchestrator(holder);
+      testWorker.addOrchestrator(waiter);
+      testWorker.addNamedEntity("counter", () => new BlockingCounterEntity());
+      await testWorker.start();
+    }
+
+    try {
+      const holderId = await client.scheduleNewOrchestration(holder);
+      const holderLocked = await waitFor(
+        () => backend.getEntity(counterId.toString())?.lockedBy === holderId,
+      );
+      expect(holderLocked).toBe(true);
+
+      const waiterId = await client.scheduleNewOrchestration(waiter);
+      await client.waitForOrchestrationStart(waiterId, false, 10);
+
+      await client.raiseOrchestrationEvent(holderId, "start");
+      await operationStarted;
+      await client.terminateOrchestration(holderId);
+      await client.waitForOrchestrationCompletion(holderId, false, 10);
+
+      expect(backend.getEntity(counterId.toString())?.lockedBy).toBeUndefined();
+
+      releaseOperation();
+      const waiterGranted = await waitFor(
+        () => backend.getEntity(counterId.toString())?.lockedBy === waiterId,
+      );
+      expect(waiterGranted).toBe(true);
+
+      await client.raiseOrchestrationEvent(waiterId, "release");
+      await client.waitForOrchestrationCompletion(waiterId, false, 10);
+    } finally {
+      releaseOperation();
+      await secondWorker.stop();
+    }
+  });
+
+  it("should synchronize the execution ID before acquiring entity locks after rewind", async () => {
+    let shouldFail = true;
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      if (shouldFail) {
+        throw new Error("Fail before acquiring the lock");
+      }
+
+      const lock = yield ctx.entities.lockEntities(counterId);
+      const value = yield ctx.entities.callEntity<number>(counterId, "add", 2);
+      lock.release();
+      return value;
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const instanceId = await client.scheduleNewOrchestration(orchestrator);
+    const failedState = await client.waitForOrchestrationCompletion(instanceId, false, 10);
+    expect(failedState?.runtimeStatus).toEqual(OrchestrationStatus.FAILED);
+    const oldExecutionId = backend.getInstance(instanceId)!.executionId;
+
+    shouldFail = false;
+    await client.rewindOrchestration(instanceId);
+    const historyRewritten = await waitFor(() => {
+      const executionId = backend
+        .getInstance(instanceId)
+        ?.history.find((event) => event.hasExecutionstarted())
+        ?.getExecutionstarted()
+        ?.getOrchestrationinstance()
+        ?.getExecutionid()
+        ?.getValue();
+      return executionId !== undefined && executionId !== oldExecutionId;
+    });
+    expect(historyRewritten).toBe(true);
+
+    const instance = backend.getInstance(instanceId)!;
+    const historyExecutionId = instance.history
+      .find((event) => event.hasExecutionstarted())!
+      .getExecutionstarted()!
+      .getOrchestrationinstance()!
+      .getExecutionid()!
+      .getValue();
+    expect(instance.executionId).toEqual(historyExecutionId);
+
+    const completedState = await client.waitForOrchestrationCompletion(instanceId, true, 10);
+    expect(completedState?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(completedState?.serializedOutput).toEqual(JSON.stringify(2));
+  });
+
+  it("should reject rewinding an orchestration with an unreleased entity lock", async () => {
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.lockEntities(counterId);
+      throw new Error("Fail while holding the lock");
+    };
+
+    worker.addOrchestrator(orchestrator);
+    await worker.start();
+
+    const instanceId = await client.scheduleNewOrchestration(orchestrator);
+    const failedState = await client.waitForOrchestrationCompletion(instanceId, false, 10);
+    expect(failedState?.runtimeStatus).toEqual(OrchestrationStatus.FAILED);
+
+    await expect(client.rewindOrchestration(instanceId)).rejects.toThrow(
+      "Cannot rewind an orchestration with an unreleased entity lock",
+    );
+  });
+
+  it("should reject rewinding a parent whose failed child has an unreleased entity lock", async () => {
+    const child: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.lockEntities(counterId);
+      throw new Error("Child failed while holding the lock");
+    };
+    const parent: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      return yield ctx.callSubOrchestrator(child);
+    };
+
+    worker.addOrchestrator(parent);
+    worker.addOrchestrator(child);
+    await worker.start();
+
+    const parentId = await client.scheduleNewOrchestration(parent);
+    const failedState = await client.waitForOrchestrationCompletion(parentId, false, 10);
+    expect(failedState?.runtimeStatus).toEqual(OrchestrationStatus.FAILED);
+
+    await expect(client.rewindOrchestration(parentId)).rejects.toThrow(
+      "Cannot rewind an orchestration with an unreleased entity lock",
+    );
+  });
+
+  it("should not rewind a child that fails after recursive rewind validation", async () => {
+    const child: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.lockEntities(counterId);
+      yield ctx.waitForExternalEvent("never");
+    };
+    const parent: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      ctx.callSubOrchestrator(child);
+      yield ctx.waitForExternalEvent("fail");
+      throw new Error("Parent failed while child was running");
+    };
+
+    worker.addOrchestrator(parent);
+    worker.addOrchestrator(child);
+    await worker.start();
+
+    const parentId = await client.scheduleNewOrchestration(parent);
+    const childCreated = await waitFor(() =>
+      backend.getInstance(parentId)!.history.some((event) => event.hasSuborchestrationinstancecreated()),
+    );
+    expect(childCreated).toBe(true);
+    const childId = backend
+      .getInstance(parentId)!
+      .history.find((event) => event.hasSuborchestrationinstancecreated())!
+      .getSuborchestrationinstancecreated()!
+      .getInstanceid();
+    const childLocked = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy === childId);
+    expect(childLocked).toBe(true);
+
+    await client.raiseOrchestrationEvent(parentId, "fail");
+    const parentState = await client.waitForOrchestrationCompletion(parentId, false, 10);
+    expect(parentState?.runtimeStatus).toEqual(OrchestrationStatus.FAILED);
+    expect(backend.getInstance(childId)?.status).toEqual(
+      pb.OrchestrationStatus.ORCHESTRATION_STATUS_RUNNING,
+    );
+    await worker.stop();
+
+    backend.rewindInstance(parentId);
+    const parentWorkItem = backend.getNextOrchestrationWorkItem()!;
+    const rewindResult = buildRewindResult(parentWorkItem.history, parentWorkItem.pendingEvents);
+
+    const childInstance = backend.getInstance(childId)!;
+    const failAction = pbh.newCompleteOrchestrationAction(
+      -1,
+      pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED,
+      undefined,
+      pbh.newFailureDetails(new Error("Child failed after validation")),
+    );
+    backend.completeOrchestration(childId, childInstance.completionToken, [failAction]);
+    backend.completeOrchestration(
+      parentId,
+      parentWorkItem.completionToken,
+      rewindResult.actions,
+      rewindResult.customStatus,
+    );
+
+    expect(backend.getInstance(childId)?.status).toEqual(
+      pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED,
+    );
+  });
+
+  it("should wait for an in-flight entity batch before granting its lock", async () => {
+    let markOperationStarted!: () => void;
+    let releaseOperation!: () => void;
+    const operationStarted = new Promise<void>((resolve) => {
+      markOperationStarted = resolve;
+    });
+    const operationReleased = new Promise<void>((resolve) => {
+      releaseOperation = resolve;
+    });
+
+    class BlockingCounterEntity extends CounterEntity {
+      async block(): Promise<void> {
+        markOperationStarted();
+        await operationReleased;
+      }
+    }
+
+    const holder: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      const value = yield ctx.entities.callEntity<number>(counterId, "get");
+      yield ctx.waitForExternalEvent("release");
+      lock.release();
+      return value;
+    };
+    const secondWorker = new TestOrchestrationWorker(backend);
+
+    for (const testWorker of [worker, secondWorker]) {
+      testWorker.addOrchestrator(holder);
+      testWorker.addNamedEntity("counter", () => new BlockingCounterEntity());
+      await testWorker.start();
+    }
+
+    try {
+      await client.signalEntity(counterId, "block");
+      await operationStarted;
+
+      const holderId = await client.scheduleNewOrchestration(holder);
+      await client.waitForOrchestrationStart(holderId, false, 10);
+
+      expect(backend.getEntity(counterId.toString())?.lockedBy).toBeUndefined();
+
+      await client.signalEntity(counterId, "add", 5);
+      releaseOperation();
+      const lockGranted = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy !== undefined);
+      expect(lockGranted).toBe(true);
+
+      await client.raiseOrchestrationEvent(holderId, "release");
+      const holderState = await client.waitForOrchestrationCompletion(holderId, true, 10);
+      expect(holderState?.serializedOutput).toEqual(JSON.stringify(0));
+
+      const signalProcessed = await waitFor(() => {
+        const serializedState = backend.getEntity(counterId.toString())?.serializedState;
+        return serializedState !== undefined && JSON.parse(serializedState).count === 5;
+      });
+      expect(signalProcessed).toBe(true);
+    } finally {
+      releaseOperation();
+      await secondWorker.stop();
+    }
   });
 
   it("should deliver a client-initiated signal to the entity", async () => {

--- a/packages/durabletask-js/test/in-memory-backend-entities.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend-entities.spec.ts
@@ -206,6 +206,121 @@ describe("In-Memory Backend - Entities", () => {
     expect(state?.serializedOutput).toContain("caught:");
   });
 
+  it("should preserve entity state when the entity factory fails", async () => {
+    let failFactory = false;
+    const orchestrator: TOrchestrator = async function* (
+      ctx: OrchestrationContext,
+      input: { operation: string; amount?: number },
+    ): any {
+      try {
+        return yield ctx.entities.callEntity<number>(counterId, input.operation, input.amount);
+      } catch (e) {
+        return `caught:${(e as Error).message}`;
+      }
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => {
+      if (failFactory) {
+        throw new Error("Intentional entity factory failure");
+      }
+      return new CounterEntity();
+    });
+    await worker.start();
+
+    const seedId = await client.scheduleNewOrchestration(orchestrator, { operation: "add", amount: 4 });
+    const seedState = await client.waitForOrchestrationCompletion(seedId, true, 10);
+    expect(seedState?.serializedOutput).toEqual(JSON.stringify(4));
+
+    failFactory = true;
+    const failureId = await client.scheduleNewOrchestration(orchestrator, { operation: "get" });
+    const failureState = await client.waitForOrchestrationCompletion(failureId, true, 10);
+    expect(failureState?.serializedOutput).toContain("Intentional entity factory failure");
+    expect((await client.getEntity<{ count: number }>(counterId))?.state?.count).toEqual(4);
+
+    failFactory = false;
+    const readId = await client.scheduleNewOrchestration(orchestrator, { operation: "get" });
+    const readState = await client.waitForOrchestrationCompletion(readId, true, 10);
+    expect(readState?.serializedOutput).toEqual(JSON.stringify(4));
+  });
+
+  it("should not deliver a stale entity result to a recreated orchestration", async () => {
+    let markOperationStarted!: () => void;
+    let releaseOperation!: () => void;
+    const operationStarted = new Promise<void>((resolve) => {
+      markOperationStarted = resolve;
+    });
+    const operationReleased = new Promise<void>((resolve) => {
+      releaseOperation = resolve;
+    });
+
+    class BlockingCounterEntity extends CounterEntity {
+      async block(): Promise<number> {
+        markOperationStarted();
+        await operationReleased;
+        return 42;
+      }
+    }
+
+    const staleCaller: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      return yield ctx.entities.callEntity<number>(counterId, "block");
+    };
+    const recreatedCaller: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.waitForExternalEvent("finish");
+      return "done";
+    };
+    const reusedInstanceId = "recreated-entity-caller";
+    const secondWorker = new TestOrchestrationWorker(backend);
+
+    for (const testWorker of [worker, secondWorker]) {
+      testWorker.addOrchestrator(staleCaller);
+      testWorker.addOrchestrator(recreatedCaller);
+      testWorker.addNamedEntity("counter", () => new BlockingCounterEntity());
+    }
+    await worker.start();
+
+    try {
+      await client.scheduleNewOrchestration(staleCaller, undefined, reusedInstanceId);
+      await operationStarted;
+
+      const dispatchedCall = backend
+        .getEntity(counterId.toString())!
+        .dispatchedOperations[0].getEntityoperationcalled()!;
+      const staleRequestId = dispatchedCall.getRequestid();
+      const staleExecutionId = dispatchedCall.getParentexecutionid()!.getValue();
+
+      await secondWorker.start();
+      await client.terminateOrchestration(reusedInstanceId);
+      await client.waitForOrchestrationCompletion(reusedInstanceId, false, 10);
+      expect((await client.purgeOrchestration(reusedInstanceId)).deletedInstanceCount).toEqual(1);
+
+      await client.scheduleNewOrchestration(recreatedCaller, undefined, reusedInstanceId);
+      await client.waitForOrchestrationStart(reusedInstanceId, false, 10);
+      expect(backend.getInstance(reusedInstanceId)?.executionId).not.toEqual(staleExecutionId);
+
+      releaseOperation();
+      const batchCompleted = await waitFor(
+        () => backend.getEntity(counterId.toString())?.dispatchedOperations.length === 0,
+      );
+      expect(batchCompleted).toBe(true);
+
+      const recreatedInstance = backend.getInstance(reusedInstanceId)!;
+      const staleResultDelivered = [...recreatedInstance.history, ...recreatedInstance.pendingEvents].some(
+        (event) =>
+          event.getEntityoperationcompleted()?.getRequestid() === staleRequestId ||
+          event.getEntityoperationfailed()?.getRequestid() === staleRequestId,
+      );
+      expect(staleResultDelivered).toBe(false);
+
+      await client.raiseOrchestrationEvent(reusedInstanceId, "finish");
+      const recreatedState = await client.waitForOrchestrationCompletion(reusedInstanceId, true, 10);
+      expect(recreatedState?.serializedOutput).toEqual(JSON.stringify("done"));
+    } finally {
+      releaseOperation();
+      await secondWorker.stop();
+    }
+  });
+
   it("should grant and release entity locks", async () => {
     const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
       const lock = yield ctx.entities.lockEntities(counterId);

--- a/packages/durabletask-js/test/in-memory-backend-entities.spec.ts
+++ b/packages/durabletask-js/test/in-memory-backend-entities.spec.ts
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+  InMemoryOrchestrationBackend,
+  TestOrchestrationClient,
+  TestOrchestrationWorker,
+  OrchestrationStatus,
+  OrchestrationContext,
+  TOrchestrator,
+  TaskEntity,
+  EntityInstanceId,
+} from "../src";
+
+class CounterEntity extends TaskEntity<{ count: number }> {
+  add(amount: number): number {
+    this.state.count += amount;
+    return this.state.count;
+  }
+
+  get(): number {
+    return this.state.count;
+  }
+
+  boom(): void {
+    throw new Error("Intentional entity failure");
+  }
+
+  relay(amount: number): void {
+    this.context?.signalEntity(new EntityInstanceId("relaytarget", "k"), "add", amount);
+  }
+
+  protected initializeState(): { count: number } {
+    return { count: 0 };
+  }
+}
+
+class RelayTargetEntity extends TaskEntity<{ count: number }> {
+  add(amount: number): number {
+    this.state.count += amount;
+    return this.state.count;
+  }
+
+  protected initializeState(): { count: number } {
+    return { count: 0 };
+  }
+}
+
+/** Waits until `predicate` holds or the timeout elapses. Returns whether it held. */
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
+describe("In-Memory Backend - Entities", () => {
+  let backend: InMemoryOrchestrationBackend;
+  let client: TestOrchestrationClient;
+  let worker: TestOrchestrationWorker;
+
+  const counterId = new EntityInstanceId("counter", "mykey");
+
+  beforeEach(() => {
+    backend = new InMemoryOrchestrationBackend();
+    client = new TestOrchestrationClient(backend);
+    worker = new TestOrchestrationWorker(backend);
+  });
+
+  afterEach(async () => {
+    try {
+      await worker.stop();
+    } catch {
+      // Ignore if not running
+    }
+    backend.reset();
+  });
+
+  it("should deliver a signal from an orchestration to the entity", async () => {
+    const orchestrator: TOrchestrator = async (ctx: OrchestrationContext): Promise<any> => {
+      ctx.entities.signalEntity(counterId, "add", 5);
+      return "signaled";
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator);
+    const state = await client.waitForOrchestrationCompletion(id, true, 10);
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+
+    // The signal is fire-and-forget, so it lands after the orchestration completes.
+    const delivered = await waitFor(() => backend.getEntity(counterId.toString())?.serializedState !== undefined);
+    expect(delivered).toBe(true);
+
+    const entity = await client.getEntity<{ count: number }>(counterId);
+    expect(entity?.state?.count).toEqual(5);
+  });
+
+  it("should batch multiple signals to the same entity", async () => {
+    const orchestrator: TOrchestrator = async (ctx: OrchestrationContext): Promise<any> => {
+      ctx.entities.signalEntity(counterId, "add", 1);
+      ctx.entities.signalEntity(counterId, "add", 2);
+      ctx.entities.signalEntity(counterId, "add", 3);
+      return "done";
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator);
+    await client.waitForOrchestrationCompletion(id, true, 10);
+
+    const settled = await waitFor(() => {
+      const entity = backend.getEntity(counterId.toString());
+      return entity?.serializedState !== undefined && JSON.parse(entity.serializedState).count === 6;
+    });
+    expect(settled).toBe(true);
+  });
+
+  it("should return the result of callEntity to the calling orchestration", async () => {
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.callEntity<number>(counterId, "add", 7);
+      const total = yield ctx.entities.callEntity<number>(counterId, "add", 3);
+      return total;
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator);
+    const state = await client.waitForOrchestrationCompletion(id, true, 30);
+
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toEqual(JSON.stringify(10));
+  });
+
+  it("should persist entity state across separate callEntity batches", async () => {
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      yield ctx.entities.callEntity<number>(counterId, "add", 4);
+      return yield ctx.entities.callEntity<number>(counterId, "get");
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator);
+    const state = await client.waitForOrchestrationCompletion(id, true, 30);
+
+    expect(state?.serializedOutput).toEqual(JSON.stringify(4));
+  });
+
+  it("should surface an entity operation failure to the calling orchestration", async () => {
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      try {
+        yield ctx.entities.callEntity(counterId, "boom");
+        return "no-error";
+      } catch (e) {
+        return `caught:${(e as Error).message}`;
+      }
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator);
+    const state = await client.waitForOrchestrationCompletion(id, true, 30);
+
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toContain("caught:");
+    expect(state?.serializedOutput).not.toContain("no-error");
+  });
+
+  it("should fail a call to an unregistered entity instead of hanging", async () => {
+    const unknownId = new EntityInstanceId("notregistered", "k");
+
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      try {
+        yield ctx.entities.callEntity(unknownId, "add", 1);
+        return "no-error";
+      } catch (e) {
+        return `caught:${(e as Error).message}`;
+      }
+    };
+
+    worker.addOrchestrator(orchestrator);
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator);
+    const state = await client.waitForOrchestrationCompletion(id, true, 30);
+
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toContain("caught:");
+  });
+
+  it("should grant and release entity locks", async () => {
+    const orchestrator: TOrchestrator = async function* (ctx: OrchestrationContext): any {
+      const lock = yield ctx.entities.lockEntities(counterId);
+      const value = yield ctx.entities.callEntity<number>(counterId, "add", 2);
+      lock.release();
+      return value;
+    };
+
+    worker.addOrchestrator(orchestrator);
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    const id = await client.scheduleNewOrchestration(orchestrator);
+    const state = await client.waitForOrchestrationCompletion(id, true, 30);
+
+    expect(state?.runtimeStatus).toEqual(OrchestrationStatus.COMPLETED);
+    expect(state?.serializedOutput).toEqual(JSON.stringify(2));
+
+    const released = await waitFor(() => backend.getEntity(counterId.toString())?.lockedBy === undefined);
+    expect(released).toBe(true);
+  });
+
+  it("should deliver a client-initiated signal to the entity", async () => {
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    await client.signalEntity(counterId, "add", 11);
+
+    const delivered = await waitFor(() => {
+      const entity = backend.getEntity(counterId.toString());
+      return entity?.serializedState !== undefined && JSON.parse(entity.serializedState).count === 11;
+    });
+    expect(delivered).toBe(true);
+
+    const metadata = await client.getEntity<{ count: number }>(counterId);
+    expect(metadata?.id.toString()).toEqual(counterId.toString());
+    expect(metadata?.includesState).toBe(true);
+    expect(metadata?.state?.count).toEqual(11);
+  });
+
+  it("should return undefined metadata for an entity that does not exist", async () => {
+    const metadata = await client.getEntity(new EntityInstanceId("counter", "absent"));
+    expect(metadata).toBeUndefined();
+  });
+
+  it("should apply a signal sent by one entity to another entity", async () => {
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    worker.addNamedEntity("relaytarget", () => new RelayTargetEntity());
+    await worker.start();
+
+    await client.signalEntity(counterId, "relay", 9);
+
+    const relayed = await waitFor(() => {
+      const target = backend.getEntity(new EntityInstanceId("relaytarget", "k").toString());
+      return target?.serializedState !== undefined && JSON.parse(target.serializedState).count === 9;
+    });
+    expect(relayed).toBe(true);
+  });
+
+  it("should clear entity state on reset", async () => {
+    worker.addNamedEntity("counter", () => new CounterEntity());
+    await worker.start();
+
+    await client.signalEntity(counterId, "add", 3);
+    const delivered = await waitFor(() => backend.getEntity(counterId.toString())?.serializedState !== undefined);
+    expect(delivered).toBe(true);
+
+    await worker.stop();
+    backend.reset();
+
+    expect(backend.getEntity(counterId.toString())).toBeUndefined();
+    expect(backend.hasPendingWork()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Any orchestration that touches an entity is **untestable** against the in-memory backend today. `processAction` has no case for `SENDENTITYMESSAGE`, so it hits the `default` branch and throws.

Proven on unpatched `main` — an orchestration whose only statement is `ctx.entities.signalEntity(...)`:

```
PROBE_RESULT status=3 failure=Unknown orchestrator action type '8' for orchestration '...'.
This likely means the in-memory backend needs to be updated to handle a newly introduced action type.
```

`status=3` is `FAILED`. Not a dropped message — the orchestration dies. Same probe with this PR:

```
PROBE_RESULT status=COMPLETED failure=none
```

## Why implement rather than fail fast

I checked all four sibling SDKs for precedent:

| SDK | In-memory testing backend | Entities in it |
|---|---|---|
| **Python** | `durabletask/testing/in_memory_backend.py` (1814 lines) | ✅ full |
| **.NET** | `InProcessTestHost/Sidecar/InMemoryOrchestrationService.cs` (944 lines) | ❌ 0 references |
| **Java** | none | n/a |
| **Go** | none (sqlite + postgres only) | n/a |
| **JS** | `src/testing/in-memory-backend.ts` (899 lines) | ❌ 0 references |

Python is the reference. Its `_process_action` dispatches `sendEntityMessage` to `_process_send_entity_message_action`, which branches on the same four oneof variants this PR handles. This change follows that design.

Worth noting: Python's dispatch handles exactly six actions and has **no** `terminateOrchestration` — independently matching the JS in-memory backend's own action set.

## What changed

**`in-memory-backend.ts`**
- `EntityState`, `EntityWorkItem`, `PendingLockRequest`; entity map, queue, and in-flight set.
- `processSendEntityMessageAction` handles all four variants. Each echoes its confirmation event into orchestration history keyed by the originating **action ID** — required so replay validation (`validateEntityAction`) matches on the next execution.
- `getNextEntityWorkItem()` drains all queued operations into one batch and marks the entity in-flight so it is not dispatched concurrently.
- `completeEntityTask()` persists state, delivers results, applies side effects, and advances the completion token so stale completions are rejected.
- Result correlation is by **index against the dispatched operations**, which is sound because `TaskEntityShim.executeAsync` pushes exactly one result per operation. `callEntity` responses become `EntityOperationCompleted` / `EntityOperationFailed` on the caller; signals are fire-and-forget and produce none.
- Lock manager: `canGrantLock` / `grantLock` / `tryGrantLock` / `tryGrantPendingLocks`; unlock releases and re-evaluates the pending queue.
- Entity side effects: `sendSignal` and `startNewOrchestration`.
- `reset()` clears entity state; `hasPendingWork()` includes the entity queue.

**`test-worker.ts`** — `addEntity` / `addNamedEntity`, entity polling in the processing loop, and batch execution through the existing `TaskEntityShim`. A call to an **unregistered** entity now fails that operation with an explanatory error instead of hanging the caller forever.

**`test-client.ts`** — `signalEntity()` and `getEntity()`, matching Python's `SignalEntity` / `GetEntity` RPCs and the real `TaskHubGrpcClient` signatures.

### Ordering detail

`grantLock` pushes `EntityLockGranted` into `parent.pendingEvents` while that same instance's actions are being processed. This is safe because `completeOrchestration` clears `pendingEvents` *before* the action loop, not after. The lock test covers it.

## Tests

11 new tests in `test/in-memory-backend-entities.spec.ts`. They assert **observable effects**, not just absence of a crash — entity state actually mutates, and `callEntity` return values reach the orchestration:

- signal from an orchestration mutates entity state
- multiple signals batch into one execution (1+2+3 → 6)
- `callEntity` returns its value to the caller
- state persists across separate batches
- a throwing operation surfaces to the caller as a catchable error
- calling an unregistered entity fails instead of hanging
- `lockEntities` grants, then `release()` unlocks
- client-initiated `signalEntity` reaches the entity
- `getEntity` returns `undefined` for a nonexistent entity
- an entity signalling another entity is delivered
- `reset()` clears entity state

## Validation

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npm run lint` | exit 0 |
| `npx jest` (durabletask-js) | **1187 passed / 1187**, 68/68 suites |
| Revert probe | orchestration `FAILED` without the fix, `COMPLETED` with it |

Baseline is 67 suites / 1176 tests; this adds 1 suite / 11 tests. No regressions.

The `azure-functions-durable` package reports 8 suites failing on `Cannot find module '@azure/functions'`. I confirmed this is **pre-existing** by stashing this branch's changes and re-running that package — identical 8 failed / 2 failed. It is a dependency-install gap in my environment, unrelated to this change.

## Scope

Matching Python, an entity is dispatched whenever it has queued operations; operations are not filtered by critical section while a lock is held. Lock state is tracked and `lockEntities` blocks other lock requests, but a concurrent *signal* to a locked entity is delivered immediately rather than deferred. Full critical-section message filtering is a larger change and is not attempted here.
