### PR TITLE
fix(release): give Azure Managed its own changelog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,12 +82,13 @@ orchestration replays, activity executions, and entity operations.
 
 ### Package Structure
 
-This is an npm workspaces monorepo with two published packages:
+This is an npm workspaces monorepo with three published packages:
 
-| Package | Role |
-|---|---|
-| Core SDK | Orchestration engine, client, worker, entities, testing, tracing |
-| Azure Managed Backend | Connection string / Entra ID auth, credential factory, builder pattern |
+| Package | Role | Changelog |
+|---|---|---|
+| Core SDK | Orchestration engine, client, worker, entities, testing, tracing | `CHANGELOG.md` |
+| Azure Managed Backend | Connection string / Entra ID auth, credential factory, builder pattern | `packages/durabletask-js-azuremanaged/CHANGELOG.md` |
+| Azure Functions Durable Provider | Azure Functions v4 compatibility provider | `packages/azure-functions-durable/CHANGELOG.md` |
 
 The Azure package **peers on** the core package — it adds authentication and connection
 management but delegates all domain logic to core.

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -58,7 +58,7 @@ jobs:
               PKG_DIR="packages/durabletask-js-azuremanaged"
               NPM_NAME="@microsoft/durabletask-js-azuremanaged"
               TAG_PREFIX="azuremanaged-v"
-              CHANGELOG_PATH="CHANGELOG.md"
+              CHANGELOG_PATH="packages/durabletask-js-azuremanaged/CHANGELOG.md"
               ;;
             azure-functions-durable)
               PKG_DIR="packages/azure-functions-durable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@
 
 ### Changes
 
-- fix: trim whitespace from tenant values in connection string parsing ([#311](https://github.com/microsoft/durabletask-js/pull/311))
-- [copilot-finds] Bug: Fix off-by-one in createServiceConfig maxRetries→maxAttempts conversion ([#287](https://github.com/microsoft/durabletask-js/pull/287))
-- [copilot-finds] Improve: Add addEntity/addNamedEntity methods to DurableTaskAzureManagedWorkerBuilder ([#266](https://github.com/microsoft/durabletask-js/pull/266))
-- Fix race condition in AccessTokenCache concurrent token fetches ([#178](https://github.com/microsoft/durabletask-js/pull/178))
-- fix: preserve error cause in getHostAddress() for better debugging ([#194](https://github.com/microsoft/durabletask-js/pull/194))
-- [copilot-finds] Bug: Connection string parser uses case-sensitive key lookup ([#196](https://github.com/microsoft/durabletask-js/pull/196))
 - feat(durable-functions): restore worker-side callHttp ([#333](https://github.com/microsoft/durabletask-js/pull/333), fixes [#318](https://github.com/microsoft/durabletask-js/issues/318))
 - [copilot-finds] Bug: Entity getState() produces unhelpful SyntaxError for corrupted state ([#309](https://github.com/microsoft/durabletask-js/pull/309))
 - fix: prevent infinite loop in suspend/resume event buffer iteration ([#306](https://github.com/microsoft/durabletask-js/pull/306))

--- a/doc/release_process.md
+++ b/doc/release_process.md
@@ -4,11 +4,11 @@ This document describes how to cut a new release of the three npm packages publi
 
 ## Overview
 
-| Package (npm name) | Directory | npm |
-|---|---|---|
-| `@microsoft/durabletask-js` (core) | `packages/durabletask-js` | [npmjs](https://www.npmjs.com/package/@microsoft/durabletask-js) |
-| `@microsoft/durabletask-js-azuremanaged` | `packages/durabletask-js-azuremanaged` | [npmjs](https://www.npmjs.com/package/@microsoft/durabletask-js-azuremanaged) |
-| `durable-functions` | `packages/azure-functions-durable` | [npmjs](https://www.npmjs.com/package/durable-functions) |
+| Package (npm name) | Directory | Changelog | npm |
+|---|---|---|---|
+| `@microsoft/durabletask-js` (core) | `packages/durabletask-js` | `CHANGELOG.md` | [npmjs](https://www.npmjs.com/package/@microsoft/durabletask-js) |
+| `@microsoft/durabletask-js-azuremanaged` | `packages/durabletask-js-azuremanaged` | `packages/durabletask-js-azuremanaged/CHANGELOG.md` | [npmjs](https://www.npmjs.com/package/@microsoft/durabletask-js-azuremanaged) |
+| `durable-functions` | `packages/azure-functions-durable` | `packages/azure-functions-durable/CHANGELOG.md` | [npmjs](https://www.npmjs.com/package/durable-functions) |
 
 This is an **npm workspaces** monorepo. The official build (`eng/ci/official-build.yml`) produces signed `.tgz` artifacts, and the **sanctioned way to publish them to npm is the ESRP release pipeline** (`eng/ci/release.yml`, see Step 3 below). A manual `npm publish` from the package directory is documented as an alternative for maintainers who need it.
 
@@ -42,16 +42,9 @@ The scheme above describes the version **string**. Mapping a version to an **npm
 
 Use the **Prepare Release** GitHub Action to automate the release preparation process.
 
-### One-Time Preflight: Seed the `azuremanaged` Release Tag
+### Automatic Legacy Baseline for Azure Managed
 
-The changelog step lists commits since the released package's **last package-scoped tag** (`git log <last-tag>..HEAD -- <pkg-dir>`); if no tag with that package's prefix exists, it falls back to the repo's initial commit and would dump the entire history into the changelog. `@microsoft/durabletask-js-azuremanaged` uses the `azuremanaged-v` prefix and has no such tag yet — the last lockstep release is the unprefixed `v0.3.0`. **Before the first independent `azuremanaged` release**, seed its tag so changelog generation starts at `v0.3.0` instead of the repo root:
-
-```bash
-git tag azuremanaged-v0.3.0 v0.3.0
-git push origin azuremanaged-v0.3.0
-```
-
-Do this once (not as part of a normal release run).
+The changelog step lists commits since the released package's **last package-scoped tag** (`git log <last-tag>..HEAD -- <pkg-dir>`). If Azure Managed has no `azuremanaged-v` tag yet, the workflow automatically checks for the legacy lockstep tag `v${CURRENT_VERSION}` and uses it as the baseline. This keeps the first independent Azure Managed changelog scoped to changes after its matching legacy release without requiring a manually seeded tag. If neither tag exists, the workflow falls back to the repository's initial commit.
 
 ### Running the Workflow
 
@@ -68,7 +61,7 @@ For the **one package you selected** (and only that package):
 1. **Determines the next version**: uses the `version` input, or auto-increments the selected package's current version
 2. **Generates a changelog**: lists commits since that package's last release tag, scoped to the package's directory (`git log <last-tag>..HEAD -- <pkg-dir>`), so only commits that touched that package are included
 3. **Bumps the version**: updates `version` in that package's own `package.json`
-4. **Updates that package's changelog**: core and azuremanaged write the repo-root `CHANGELOG.md`; `durable-functions` writes `packages/azure-functions-durable/CHANGELOG.md`
+4. **Updates that package's changelog**: core writes `CHANGELOG.md`, Azure Managed writes `packages/durabletask-js-azuremanaged/CHANGELOG.md`, and `durable-functions` writes `packages/azure-functions-durable/CHANGELOG.md`
 5. **Creates a release branch and a package-scoped tag**: tag `<prefix><version>` and branch `release/<prefix><version>`, where the prefix is `v` (core), `azuremanaged-v`, or `durable-functions-v`
 6. **For `durable-functions` only**: verifies the exact-pinned `@microsoft/durabletask-js` version is already published on public npm, and fails the run if it is not (guards the uninstallable-dependency case)
 
@@ -149,7 +142,7 @@ Go to [GitHub Releases](https://github.com/microsoft/durabletask-js/releases) an
 
 - **Tag**: the package-scoped tag created by the release — e.g. `durable-functions-v4.0.0-beta.1`, `azuremanaged-v0.3.0`, or `v0.4.0`
 - **Title**: the same tag, or `<npm-name>@<version>`
-- **Description**: copy the relevant section from that package's changelog (`CHANGELOG.md` for core / azuremanaged, `packages/azure-functions-durable/CHANGELOG.md` for `durable-functions`)
+- **Description**: copy the relevant section from that package's changelog: `CHANGELOG.md` for core, `packages/durabletask-js-azuremanaged/CHANGELOG.md` for Azure Managed, or `packages/azure-functions-durable/CHANGELOG.md` for `durable-functions`
 - **Pre-release**: check this box for alpha/beta/rc/preview releases
 
 ## Manual Release Process (Alternative)
@@ -190,7 +183,13 @@ Then update the affected cross-package dependency **for the package you are rele
 
 ### 3. Update the Changelog
 
-Move items from the `## Upcoming` section of the package's changelog into a new versioned section. The changelog is a **generated** list of the released package's commit messages / PR links — not a place for hand-authored breaking-change narrative; detailed preview and migration guidance lives in `packages/azure-functions-durable/README.md` (for `durable-functions`), not the changelog. To reproduce the tooling manually, promote any curated `## Upcoming` notes into the new section and add one `### Changes` entry per commit, mirroring `git log <last-tag>..HEAD -- <pkg-dir>` (each commit subject with its `(#NN)` linked). Use the repo-root `CHANGELOG.md` for `@microsoft/durabletask-js` and `@microsoft/durabletask-js-azuremanaged`, or `packages/azure-functions-durable/CHANGELOG.md` for `durable-functions`:
+Move items from the `## Upcoming` section of the package's changelog into a new versioned section. The changelog is a **generated** list of the released package's commit messages / PR links — not a place for hand-authored breaking-change narrative; detailed preview and migration guidance lives in `packages/azure-functions-durable/README.md` (for `durable-functions`), not the changelog. To reproduce the tooling manually, promote any curated `## Upcoming` notes into the new section and add one `### Changes` entry per commit, mirroring `git log <last-tag>..HEAD -- <pkg-dir>` (each commit subject with its `(#NN)` linked). Update only the released package's changelog:
+
+| Package | Changelog |
+|---|---|
+| `@microsoft/durabletask-js` | `CHANGELOG.md` |
+| `@microsoft/durabletask-js-azuremanaged` | `packages/durabletask-js-azuremanaged/CHANGELOG.md` |
+| `durable-functions` | `packages/azure-functions-durable/CHANGELOG.md` |
 
 ```markdown
 ## Upcoming

--- a/packages/durabletask-js-azuremanaged/CHANGELOG.md
+++ b/packages/durabletask-js-azuremanaged/CHANGELOG.md
@@ -1,0 +1,18 @@
+## Upcoming
+
+### New
+
+### Fixes
+
+## v0.4.0 (2026-07-31)
+
+### Changes
+
+- fix: trim whitespace from tenant values in connection string parsing ([#311](https://github.com/microsoft/durabletask-js/pull/311))
+- [copilot-finds] Bug: Fix off-by-one in createServiceConfig maxRetries→maxAttempts conversion ([#287](https://github.com/microsoft/durabletask-js/pull/287))
+- [copilot-finds] Improve: Add addEntity/addNamedEntity methods to DurableTaskAzureManagedWorkerBuilder ([#266](https://github.com/microsoft/durabletask-js/pull/266))
+- Fix race condition in AccessTokenCache concurrent token fetches ([#178](https://github.com/microsoft/durabletask-js/pull/178))
+- build(deps): bump @grpc/grpc-js ([#259](https://github.com/microsoft/durabletask-js/pull/259))
+- fix: preserve error cause in getHostAddress() for better debugging ([#194](https://github.com/microsoft/durabletask-js/pull/194))
+- [copilot-finds] Bug: Connection string parser uses case-sensitive key lookup ([#196](https://github.com/microsoft/durabletask-js/pull/196))
+- feat: Implement work item filters ([#168](https://github.com/microsoft/durabletask-js/pull/168))

--- a/packages/durabletask-js-azuremanaged/package.json
+++ b/packages/durabletask-js-azuremanaged/package.json
@@ -13,6 +13,7 @@
   },
   "files": [
     "dist",
+    "CHANGELOG.md",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
## Summary

- give `@microsoft/durabletask-js-azuremanaged` its own generated changelog with the eight changes since the legacy v0.3.0 baseline
- restore the root changelog to its pre-release content so it remains core-owned
- route release preparation and package contents to the Azure Managed changelog, and align release documentation

## Validation

- release metadata resolves all three packages to distinct changelog paths
- isolated Azure Managed changelog update leaves the root changelog unchanged
- root changelog matches the pre-#343 blob exactly
- Azure Managed changelog contains one v0.4.0 section and exactly the expected eight PR links
- Azure Managed build and 109 unit tests pass
- Azure Managed `npm pack --dry-run` includes `CHANGELOG.md`
- workflow YAML parsing, repository lint, and `git diff --check` pass

## Release correction

Official build 294725 was produced from merge commit `2957815e652b9fad8d3d065ec8b01f00b1fb88b3`, before this changelog ownership correction, so it must not be used for publishing. After this PR merges, run/select a new official build whose source is the new exact `main` commit before any ESRP release.

Do not merge this PR until checks and review are complete. This PR does not publish, run ESRP, or change tags.