### PR TITLE
fix(release): publish durable-functions v4 to preview-v4

### DIFF
--- a/packages/azure-functions-durable/package.json
+++ b/packages/azure-functions-durable/package.json
@@ -1,6 +1,9 @@
 {
   "name": "durable-functions",
   "version": "4.0.0-beta.1",
+  "publishConfig": {
+    "tag": "preview-v4"
+  },
   "description": "Azure Functions Durable provider for the Durable Task JavaScript SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- set the durable-functions package's default npm dist-tag to `preview-v4`
- preserve package name `durable-functions` and version `4.0.0-beta.1`

This causes npm to use `preview-v4` as the default dist-tag when this package is published.

No package was published.

## Validation
- parsed the manifest with Node.js and verified name, version, and `publishConfig.tag`
- checked formatting with the repository's Prettier 3.5.3 configuration
- confirmed the diff changes only `packages/azure-functions-durable/package.json`