### PR TITLE
Stop recording registry URLs in the Functions test lockfile

### DIFF
--- a/test/e2e-functions/test-app/.npmrc
+++ b/test/e2e-functions/test-app/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/test/e2e-functions/test-app/package-lock.json
+++ b/test/e2e-functions/test-app/package-lock.json
@@ -39,7 +39,6 @@
         },
         "node_modules/@azure/functions": {
             "version": "4.16.2",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/functions/-/functions-4.16.2.tgz",
             "integrity": "sha1-e/GOBuS1+Ss2i0I8xX/pu2WI788=",
             "license": "MIT",
             "dependencies": {
@@ -52,7 +51,6 @@
         },
         "node_modules/@azure/functions-extensions-base": {
             "version": "0.3.0",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
             "integrity": "sha1-cGLy8GmLtkdwN4+eev+fd8Ukn04=",
             "license": "MIT",
             "engines": {
@@ -61,7 +59,6 @@
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
             "dev": true,
             "license": "ISC",
@@ -79,7 +76,6 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
             "dev": true,
             "license": "MIT",
@@ -90,7 +86,6 @@
         },
         "node_modules/@types/node": {
             "version": "20.19.43",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-20.19.43.tgz",
             "integrity": "sha1-/Oz1gLpCoNtVz0BMNyyXlzw3bJc=",
             "dev": true,
             "license": "MIT",
@@ -100,7 +95,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "6.2.2",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
             "dev": true,
             "license": "MIT",
@@ -113,7 +107,6 @@
         },
         "node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
             "dev": true,
             "license": "MIT",
@@ -126,14 +119,12 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "2.1.2",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
             "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
             "dev": true,
             "license": "MIT",
@@ -143,7 +134,6 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
             "dev": true,
             "license": "MIT",
@@ -156,14 +146,12 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "0.7.2",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha1-VWNpxHKiupEPKXmJG1JrNDYjftc=",
             "license": "MIT",
             "engines": {
@@ -172,7 +160,6 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
             "dev": true,
             "license": "MIT",
@@ -191,21 +178,18 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/foreground-child": {
             "version": "3.3.1",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
             "dev": true,
             "license": "ISC",
@@ -222,7 +206,6 @@
         },
         "node_modules/glob": {
             "version": "10.5.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-10.5.0.tgz",
             "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
@@ -244,7 +227,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
             "dev": true,
             "license": "MIT",
@@ -254,14 +236,12 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
             "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -277,14 +257,12 @@
         },
         "node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/minimatch": {
             "version": "9.0.9",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
             "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
             "dev": true,
             "license": "ISC",
@@ -300,7 +278,6 @@
         },
         "node_modules/minipass": {
             "version": "7.1.3",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -310,14 +287,12 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
             "dev": true,
             "license": "MIT",
@@ -327,7 +302,6 @@
         },
         "node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -344,7 +318,6 @@
         },
         "node_modules/rimraf": {
             "version": "5.0.10",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rimraf/-/rimraf-5.0.10.tgz",
             "integrity": "sha1-I7mEPT3JLbcfluGizpLjn9KoIhw=",
             "dev": true,
             "license": "ISC",
@@ -360,7 +333,6 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
             "dev": true,
             "license": "MIT",
@@ -373,7 +345,6 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
             "dev": true,
             "license": "MIT",
@@ -383,7 +354,6 @@
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
             "dev": true,
             "license": "ISC",
@@ -396,7 +366,6 @@
         },
         "node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
             "dev": true,
             "license": "MIT",
@@ -415,7 +384,6 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
             "dev": true,
             "license": "MIT",
@@ -430,7 +398,6 @@
         },
         "node_modules/string-width-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
             "dev": true,
             "license": "MIT",
@@ -440,14 +407,12 @@
         },
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
             "dev": true,
             "license": "MIT",
@@ -460,7 +425,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "7.2.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
             "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
             "dev": true,
             "license": "MIT",
@@ -477,7 +441,6 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
             "dev": true,
             "license": "MIT",
@@ -490,7 +453,6 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
             "dev": true,
             "license": "MIT",
@@ -500,7 +462,6 @@
         },
         "node_modules/typescript": {
             "version": "4.9.5",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha1-CVl5+bzA0J2jJNWNA86Pg3TL5lo=",
             "dev": true,
             "license": "Apache-2.0",
@@ -514,14 +475,12 @@
         },
         "node_modules/undici-types": {
             "version": "6.23.0",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-6.23.0.tgz",
             "integrity": "sha1-UpEUTImcnIaJaPuoD93ZxI3vdfk=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
             "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
             "dev": true,
             "license": "ISC",
@@ -537,7 +496,6 @@
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
             "dev": true,
             "license": "MIT",
@@ -556,7 +514,6 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
             "dev": true,
             "license": "MIT",
@@ -574,7 +531,6 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
             "dev": true,
             "license": "MIT",
@@ -584,7 +540,6 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
             "dev": true,
             "license": "MIT",
@@ -600,14 +555,12 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
             "dev": true,
             "license": "MIT",
@@ -622,7 +575,6 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
             "dev": true,
             "license": "MIT",


### PR DESCRIPTION
# Summary

The Functions test app no longer records npm registry URLs in its lockfile. Dependency versions, integrity hashes, lockfile version 3, local package links, and platform metadata remain unchanged.

## What changed?
- Added `omit-lockfile-registry-resolved=true` to `test/e2e-functions/test-app/.npmrc`.
- Regenerated the test app lockfile with npm 10.9.4 and limited the diff to registry `resolved` fields.

## Why is this change needed?
- The lockfile recorded Azure Artifacts proxy URLs. Those URLs depend on the registry used to generate the lockfile.
- Future lockfile updates will use the active npm registry without committing its tarball host.

## Issues / work items
- Resolves: N/A
- Related: N/A

---

# Project checklist
- [x] Release notes are not required for the next release
  - [ ] Otherwise: Notes added to `CHANGELOG.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact:
    - Migration guidance:

---

# AI-assisted code disclosure (required)

## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI
- AI-assisted areas/files: `.npmrc`, `package-lock.json`, validation, commit message, and pull request description
- What you changed after AI output: Kept the lockfile diff to registry `resolved` fields and verified the generated result.

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing

## Automated tests
- Result: Passed
- `npx --yes npm@10.9.4 config get omit-lockfile-registry-resolved`
- `npx --yes npm@10.9.4 install --package-lock-only --ignore-scripts --no-audit --no-fund`
- Repeated lockfile generation and confirmed a clean result
- `npx --yes npm@10.9.4 ci --ignore-scripts --no-audit --no-fund`
- `npm ci` at the repository root
- `npm run build -w durable-functions`
- `npm run build` in the test app
- `npm test` in the test app (`No tests yet...`)

Lockfile checks:

```text
config=true
target_feed_urls=0
all_registry_resolved=0
metadata_preserved=true
second_regeneration_clean=true
```

## Manual validation (only if runtime/behavior changed)
- Environment (OS, Node.js version, components): N/A
- Steps + observed results:
  1. N/A. Runtime behavior did not change.
- Evidence (optional): N/A

---

# Notes for reviewers
- The test app uses local `file:` dependencies, so the in-repository `durable-functions` package must be built before the test app build.
- The existing locked file dependency metadata was preserved to avoid unrelated version and peer dependency changes.
