### PR TITLE
fix: reconnect silent worker streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
 
 - Bound each worker sidecar hello attempt to 30 seconds, retry failed connections, and cancel
   pending hello calls and reconnect delays when the worker stops.
-- Reconnect worker work-item streams after 120 seconds without a message or health ping, with
-  `silentDisconnectTimeoutMs` available to configure the silence window.
+- Align worker stream recovery with the .NET SDK: reconnect after 120 seconds without a message
+  or health ping, reset retry state only after the first message, use full-jitter backoff, reuse
+  channels until five likely-poisoned failures, and defer disposal of replaced channels.
 
 ## v0.4.0 (2026-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
   pending hello calls and reconnect delays when the worker stops.
 - Align worker stream recovery with the .NET SDK: reconnect after 120 seconds without a message
   or health ping, reset retry state only after the first message, use full-jitter backoff, reuse
-  channels until five likely-poisoned failures, and defer disposal of replaced channels.
+  channels until five likely-poisoned failures, isolate recreated grpc-js transports, and defer
+  disposal of replaced channels. Sidecars that do not send health-ping work items, including the
+  current durabletask-go sidecar, should set `silentDisconnectTimeoutMs` to `0`.
 
 ## v0.4.0 (2026-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Bound each worker sidecar hello attempt to 30 seconds, retry failed connections, and cancel
   pending hello calls and reconnect delays when the worker stops.
+- Reconnect worker work-item streams after 120 seconds without a message or health ping, with
+  `silentDisconnectTimeoutMs` available to configure the silence window.
 
 ## v0.4.0 (2026-07-31)
 

--- a/packages/durabletask-js-azuremanaged/CHANGELOG.md
+++ b/packages/durabletask-js-azuremanaged/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `DurableTaskAzureManagedWorkerBuilder.silentDisconnectTimeout()` to configure the
   core worker's work-item stream watchdog.
+- Add `DurableTaskAzureManagedWorkerBuilder.channelRecreateFailureThreshold()` to control when
+  consecutive likely-poisoned failures recreate the gRPC channel.
 
 ### Fixes
 

--- a/packages/durabletask-js-azuremanaged/CHANGELOG.md
+++ b/packages/durabletask-js-azuremanaged/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### New
 
+- Add `DurableTaskAzureManagedWorkerBuilder.silentDisconnectTimeout()` to configure the
+  core worker's work-item stream watchdog.
+
 ### Fixes
 
 ## v0.4.0 (2026-07-31)

--- a/packages/durabletask-js-azuremanaged/CHANGELOG.md
+++ b/packages/durabletask-js-azuremanaged/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### New
 
 - Add `DurableTaskAzureManagedWorkerBuilder.silentDisconnectTimeout()` to configure the
-  core worker's work-item stream watchdog.
+  core worker's work-item stream watchdog. Set it to `0` for sidecars that do not emit
+  health-ping work items, including the current durabletask-go sidecar.
 - Add `DurableTaskAzureManagedWorkerBuilder.channelRecreateFailureThreshold()` to control when
   consecutive likely-poisoned failures recreate the gRPC channel.
 

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -242,6 +242,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
    * Sets the maximum time between work-item stream messages before reconnecting.
    * Health pings reset this deadline. Defaults to 120000 (2 minutes).
    * Non-positive values disable detection.
+   * Set this to 0 when connecting to a sidecar that does not emit health-ping work items.
    *
    * @param timeoutMs The silent disconnect timeout in milliseconds.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -29,6 +29,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
   private _entities: { name?: string; factory: EntityFactory }[] = [];
   private _logger: Logger = new ConsoleLogger();
   private _shutdownTimeoutMs?: number;
+  private _silentDisconnectTimeoutMs?: number;
   private _versioning?: VersioningOptions;
   private _workItemFilters?: WorkItemFilters | "auto";
 
@@ -237,6 +238,18 @@ export class DurableTaskAzureManagedWorkerBuilder {
   }
 
   /**
+   * Sets the maximum time between work-item stream messages before reconnecting.
+   * Health pings reset this deadline. Defaults to 120000 (2 minutes).
+   *
+   * @param timeoutMs The silent disconnect timeout in milliseconds.
+   * @returns This builder instance.
+   */
+  silentDisconnectTimeout(timeoutMs: number): DurableTaskAzureManagedWorkerBuilder {
+    this._silentDisconnectTimeoutMs = timeoutMs;
+    return this;
+  }
+
+  /**
    * Configures versioning options for the worker.
    * This allows filtering orchestrations by version using different match strategies.
    *
@@ -293,6 +306,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
       metadataGenerator,
       logger: this._logger,
       shutdownTimeoutMs: this._shutdownTimeoutMs,
+      silentDisconnectTimeoutMs: this._silentDisconnectTimeoutMs,
       versioning: this._versioning,
       workItemFilters: this._workItemFilters,
     });

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -30,6 +30,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
   private _logger: Logger = new ConsoleLogger();
   private _shutdownTimeoutMs?: number;
   private _silentDisconnectTimeoutMs?: number;
+  private _channelRecreateFailureThreshold?: number;
   private _versioning?: VersioningOptions;
   private _workItemFilters?: WorkItemFilters | "auto";
 
@@ -240,12 +241,25 @@ export class DurableTaskAzureManagedWorkerBuilder {
   /**
    * Sets the maximum time between work-item stream messages before reconnecting.
    * Health pings reset this deadline. Defaults to 120000 (2 minutes).
+   * Non-positive values disable detection.
    *
    * @param timeoutMs The silent disconnect timeout in milliseconds.
    * @returns This builder instance.
    */
   silentDisconnectTimeout(timeoutMs: number): DurableTaskAzureManagedWorkerBuilder {
     this._silentDisconnectTimeoutMs = timeoutMs;
+    return this;
+  }
+
+  /**
+   * Sets the consecutive likely-poisoned failure threshold for recreating the gRPC channel.
+   * Defaults to 5. Non-positive values disable channel recreation.
+   *
+   * @param threshold The channel recreation failure threshold.
+   * @returns This builder instance.
+   */
+  channelRecreateFailureThreshold(threshold: number): DurableTaskAzureManagedWorkerBuilder {
+    this._channelRecreateFailureThreshold = threshold;
     return this;
   }
 
@@ -307,6 +321,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
       logger: this._logger,
       shutdownTimeoutMs: this._shutdownTimeoutMs,
       silentDisconnectTimeoutMs: this._silentDisconnectTimeoutMs,
+      channelRecreateFailureThreshold: this._channelRecreateFailureThreshold,
       versioning: this._versioning,
       workItemFilters: this._workItemFilters,
     });

--- a/packages/durabletask-js-azuremanaged/test/unit/worker-builder.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/worker-builder.spec.ts
@@ -90,4 +90,15 @@ describe("DurableTaskAzureManagedWorkerBuilder", () => {
       expect(result).toBe(builder);
     });
   });
+
+  describe("silentDisconnectTimeout", () => {
+    it("forwards the configured timeout to the core worker", () => {
+      const builder = new DurableTaskAzureManagedWorkerBuilder().endpoint(ENDPOINT, TASKHUB, null);
+
+      expect(builder.silentDisconnectTimeout(5000)).toBe(builder);
+      const worker = builder.build();
+
+      expect((worker as any)._silentDisconnectTimeoutMs).toBe(5000);
+    });
+  });
 });

--- a/packages/durabletask-js-azuremanaged/test/unit/worker-builder.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/worker-builder.spec.ts
@@ -101,4 +101,15 @@ describe("DurableTaskAzureManagedWorkerBuilder", () => {
       expect((worker as any)._silentDisconnectTimeoutMs).toBe(5000);
     });
   });
+
+  describe("channelRecreateFailureThreshold", () => {
+    it("forwards the configured threshold to the core worker", () => {
+      const builder = new DurableTaskAzureManagedWorkerBuilder().endpoint(ENDPOINT, TASKHUB, null);
+
+      expect(builder.channelRecreateFailureThreshold(3)).toBe(builder);
+      const worker = builder.build();
+
+      expect((worker as any)._channelRecreateFailureThreshold).toBe(3);
+    });
+  });
 });

--- a/packages/durabletask-js/src/utils/backoff.util.ts
+++ b/packages/durabletask-js/src/utils/backoff.util.ts
@@ -34,6 +34,13 @@ export interface BackoffOptions {
    * @default 0.1
    */
   jitterFactor?: number;
+
+  /**
+   * Jitter distribution. "symmetric" preserves the default range around the delay;
+   * "full" selects uniformly from zero through the exponential upper bound.
+   * @default "symmetric"
+   */
+  jitterStrategy?: "symmetric" | "full";
 }
 
 /**
@@ -45,6 +52,7 @@ export const DEFAULT_BACKOFF_OPTIONS: Required<BackoffOptions> = {
   multiplier: 2,
   maxAttempts: -1,
   jitterFactor: 0.1,
+  jitterStrategy: "symmetric",
 };
 
 /**
@@ -72,6 +80,7 @@ export class ExponentialBackoff {
   private readonly _multiplier: number;
   private readonly _maxAttempts: number;
   private readonly _jitterFactor: number;
+  private readonly _jitterStrategy: "symmetric" | "full";
 
   private _currentDelayMs: number;
   private _attemptCount: number;
@@ -84,6 +93,7 @@ export class ExponentialBackoff {
     this._multiplier = opts.multiplier;
     this._maxAttempts = opts.maxAttempts;
     this._jitterFactor = opts.jitterFactor;
+    this._jitterStrategy = opts.jitterStrategy;
 
     this._currentDelayMs = this._initialDelayMs;
     this._attemptCount = 0;
@@ -117,6 +127,9 @@ export class ExponentialBackoff {
    * Calculates the next delay with optional jitter.
    */
   private _calculateDelayWithJitter(): number {
+    if (this._jitterStrategy === "full") {
+      return Math.floor(Math.random() * this._currentDelayMs);
+    }
     if (this._jitterFactor <= 0) {
       return this._currentDelayMs;
     }
@@ -131,14 +144,16 @@ export class ExponentialBackoff {
    * and calculates the next delay.
    *
    * @param signal Optional signal that cancels the pending delay.
+   * @param onDelay Optional callback invoked with the jittered delay before waiting.
    * @returns Promise that resolves after the delay or rejects when aborted.
    */
-  async wait(signal?: AbortSignal): Promise<void> {
+  async wait(signal?: AbortSignal, onDelay?: (delayMs: number) => void): Promise<void> {
     const delay = this._calculateDelayWithJitter();
 
     if (signal?.aborted) {
       throw signal.reason;
     }
+    onDelay?.(delay);
 
     await new Promise<void>((resolve, reject) => {
       const onAbort = () => {

--- a/packages/durabletask-js/src/worker/logs.ts
+++ b/packages/durabletask-js/src/worker/logs.ts
@@ -77,6 +77,9 @@ const CATEGORY_ENTITIES = "Microsoft.DurableTask.Worker.Entities";
 /** @internal */ export const EVENT_ACTIVITY_RESPONSE_ERROR = 735;
 /** @internal */ export const EVENT_STREAM_ERROR_INFO = 736;
 /** @internal */ export const EVENT_RETRY_HANDLER_EXCEPTION = 737;
+/** @internal */ export const EVENT_STREAM_TIMEOUT = 738;
+/** @internal */ export const EVENT_CHANNEL_RECREATING = 739;
+/** @internal */ export const EVENT_CHANNEL_RECREATED = 740;
 
 // ── Entity-specific Event IDs (800+ range) ──────────────────────────────────
 
@@ -239,6 +242,30 @@ export function streamEnded(logger: Logger): void {
     eventId: EVENT_STREAM_ENDED,
     category: CATEGORY_WORKER,
   }, "Stream ended");
+}
+
+export function streamTimeout(logger: Logger, timeoutMs: number): void {
+  emitLog(logger, "warn", {
+    eventId: EVENT_STREAM_TIMEOUT,
+    category: CATEGORY_WORKER,
+    properties: { timeoutMs },
+  }, `Channel to backend has stopped receiving traffic for ${timeoutMs}ms and will reconnect.`);
+}
+
+export function channelRecreating(logger: Logger, failureCount: number): void {
+  emitLog(logger, "warn", {
+    eventId: EVENT_CHANNEL_RECREATING,
+    category: CATEGORY_WORKER,
+    properties: { failureCount },
+  }, `Recreating gRPC channel to backend after ${failureCount} consecutive transport failures.`);
+}
+
+export function channelRecreated(logger: Logger, hostAddress: string): void {
+  emitLog(logger, "info", {
+    eventId: EVENT_CHANNEL_RECREATED,
+    category: CATEGORY_WORKER,
+    properties: { hostAddress },
+  }, `gRPC channel to backend has been recreated for ${hostAddress}.`);
 }
 
 export function streamRetry(logger: Logger, delayMs: number): void {

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -40,6 +40,9 @@ import {
 
 /** Default timeout in milliseconds for graceful shutdown. */
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30000;
+/** Default maximum silence between work-item stream messages. */
+const DEFAULT_SILENT_DISCONNECT_TIMEOUT_MS = 120000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const HELLO_TIMEOUT_MS = 30000;
 
 /**
@@ -60,6 +63,12 @@ export interface TaskHubGrpcWorkerOptions {
   logger?: Logger;
   /** Optional timeout in milliseconds for graceful shutdown. Defaults to 30000. */
   shutdownTimeoutMs?: number;
+  /**
+   * Maximum time in milliseconds between work-item stream messages before reconnecting.
+   * Health pings reset this deadline. Defaults to 120000 (2 minutes).
+   * Must be a positive finite number no greater than 2147483647.
+   */
+  silentDisconnectTimeoutMs?: number;
   /** Optional versioning options for filtering orchestrations by version. */
   versioning?: VersioningOptions;
   /**
@@ -86,6 +95,8 @@ export class TaskHubGrpcWorker {
   private _logger: Logger;
   private _pendingWorkItems: Set<Promise<void>>;
   private _shutdownTimeoutMs: number;
+  private _silentDisconnectTimeoutMs: number;
+  private _silentDisconnectTimer: ReturnType<typeof setTimeout> | null;
   private _backoff: ExponentialBackoff;
   private _versioning?: VersioningOptions;
   private _workItemFilters?: WorkItemFilters | "auto";
@@ -136,6 +147,7 @@ export class TaskHubGrpcWorker {
     let resolvedMetadataGenerator: MetadataGenerator | undefined;
     let resolvedLogger: Logger | undefined;
     let resolvedShutdownTimeoutMs: number | undefined;
+    let resolvedSilentDisconnectTimeoutMs: number | undefined;
     let resolvedVersioning: VersioningOptions | undefined;
     let resolvedWorkItemFilters: WorkItemFilters | "auto" | undefined;
 
@@ -148,6 +160,7 @@ export class TaskHubGrpcWorker {
       resolvedMetadataGenerator = hostAddressOrOptions.metadataGenerator;
       resolvedLogger = hostAddressOrOptions.logger;
       resolvedShutdownTimeoutMs = hostAddressOrOptions.shutdownTimeoutMs;
+      resolvedSilentDisconnectTimeoutMs = hostAddressOrOptions.silentDisconnectTimeoutMs;
       resolvedVersioning = hostAddressOrOptions.versioning;
       resolvedWorkItemFilters = hostAddressOrOptions.workItemFilters;
     } else {
@@ -174,6 +187,19 @@ export class TaskHubGrpcWorker {
     this._logger = resolvedLogger ?? new ConsoleLogger();
     this._pendingWorkItems = new Set();
     this._shutdownTimeoutMs = resolvedShutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+    const silentDisconnectTimeoutMs = resolvedSilentDisconnectTimeoutMs ?? DEFAULT_SILENT_DISCONNECT_TIMEOUT_MS;
+    if (!Number.isFinite(silentDisconnectTimeoutMs) || silentDisconnectTimeoutMs <= 0) {
+      throw new RangeError(
+        `silentDisconnectTimeoutMs must be a positive finite number, got ${silentDisconnectTimeoutMs}`,
+      );
+    }
+    if (silentDisconnectTimeoutMs > MAX_TIMER_DELAY_MS) {
+      throw new RangeError(
+        `silentDisconnectTimeoutMs must be no greater than ${MAX_TIMER_DELAY_MS}, got ${silentDisconnectTimeoutMs}`,
+      );
+    }
+    this._silentDisconnectTimeoutMs = silentDisconnectTimeoutMs;
+    this._silentDisconnectTimer = null;
     this._backoff = new ExponentialBackoff({
       initialDelayMs: 1000,
       maxDelayMs: 30000,
@@ -450,8 +476,62 @@ export class TaskHubGrpcWorker {
 
       WorkerLogs.workerConnected(this._logger, this._hostAddress ?? "localhost:4001");
 
+      let silentDisconnectTimer: ReturnType<typeof setTimeout> | undefined;
+      let streamTerminated = false;
+      const clearSilentDisconnectTimer = () => {
+        if (silentDisconnectTimer !== undefined) {
+          clearTimeout(silentDisconnectTimer);
+          if (this._silentDisconnectTimer === silentDisconnectTimer) {
+            this._silentDisconnectTimer = null;
+          }
+          silentDisconnectTimer = undefined;
+        }
+      };
+      const terminateStream = (reconnect: boolean, cancel: boolean) => {
+        if (streamTerminated) {
+          return;
+        }
+        streamTerminated = true;
+        clearSilentDisconnectTimer();
+        if (this._responseStream === stream) {
+          this._responseStream = null;
+        }
+        stream.removeAllListeners();
+        stream.on("error", () => {}); // Prevent unhandled stale errors after cleanup.
+        if (cancel) {
+          stream.cancel();
+        }
+        stream.destroy();
+
+        if (reconnect && !signal?.aborted && !this._stopWorker) {
+          WorkerLogs.streamRetry(this._logger, this._backoff.peekNextDelay());
+          this._createNewClientAndRetry(signal).catch((retryErr) => {
+            if (!signal?.aborted && !this._stopWorker) {
+              WorkerLogs.workerError(this._logger, retryErr instanceof Error ? retryErr : new Error(String(retryErr)));
+            }
+          });
+        }
+      };
+      const armSilentDisconnectTimer = () => {
+        clearSilentDisconnectTimer();
+        const timer = setTimeout(() => {
+          if (silentDisconnectTimer !== timer) {
+            return;
+          }
+          clearSilentDisconnectTimer();
+          terminateStream(true, true);
+        }, this._silentDisconnectTimeoutMs);
+        silentDisconnectTimer = timer;
+        this._silentDisconnectTimer = timer;
+        timer.unref();
+      };
+
       // Wait for a work item to be received
       stream.on("data", (workItem: pb.WorkItem) => {
+        if (streamTerminated || signal?.aborted || this._stopWorker) {
+          return;
+        }
+        armSilentDisconnectTimer();
         const completionToken = workItem.getCompletiontoken();
         if (workItem.hasOrchestratorrequest()) {
           WorkerLogs.workItemReceived(
@@ -482,43 +562,23 @@ export class TaskHubGrpcWorker {
       stream.on("end", () => {
         if (signal?.aborted || this._stopWorker) {
           WorkerLogs.streamEnded(this._logger);
-          stream.removeAllListeners();
-          stream.destroy();
+          terminateStream(false, false);
           return;
         }
-        // Stream ended unexpectedly - clean up and retry
-        stream.removeAllListeners();
-        stream.on("error", () => {}); // Prevent unhandled "error" after cleanup
-        stream.destroy();
-        WorkerLogs.streamRetry(this._logger, this._backoff.peekNextDelay());
-        this._createNewClientAndRetry(signal).catch((retryErr) => {
-          if (!signal?.aborted && !this._stopWorker) {
-            WorkerLogs.workerError(this._logger, retryErr instanceof Error ? retryErr : new Error(String(retryErr)));
-          }
-        });
+        terminateStream(true, false);
       });
 
       stream.on("error", (err: Error) => {
         // Ignore cancellation errors when the worker is being stopped intentionally
         if (signal?.aborted || this._stopWorker) {
+          clearSilentDisconnectTimer();
           return;
         }
         WorkerLogs.streamErrorInfo(this._logger, err);
-
-        // Clean up the errored stream and retry the connection.
-        // In Node.js, gRPC stream errors (e.g., UNAVAILABLE, transport failures)
-        // may not always be followed by an "end" event. Without recovery here,
-        // the worker would silently stop processing work items.
-        stream.removeAllListeners();
-        stream.on("error", () => {}); // Prevent unhandled "error" after cleanup
-        stream.destroy();
-        WorkerLogs.streamRetry(this._logger, this._backoff.peekNextDelay());
-        this._createNewClientAndRetry(signal).catch((retryErr) => {
-          if (!signal?.aborted && !this._stopWorker) {
-            WorkerLogs.workerError(this._logger, retryErr instanceof Error ? retryErr : new Error(String(retryErr)));
-          }
-        });
+        terminateStream(true, false);
       });
+
+      armSilentDisconnectTimer();
     } catch (err) {
       if (signal?.aborted || this._stopWorker) {
         // ignoring the error because the worker has been stopped
@@ -544,6 +604,7 @@ export class TaskHubGrpcWorker {
     const responseStream = this._responseStream;
     this._stopWorker = true;
     this._abortController?.abort();
+    this._clearSilentDisconnectTimer();
 
     // Cancel stream first while error handlers are still attached
     // This allows the error handler to suppress CANCELLED errors
@@ -602,6 +663,13 @@ export class TaskHubGrpcWorker {
     // Brief pause to allow gRPC cleanup
     // https://github.com/grpc/grpc-node/issues/1563#issuecomment-829483711
     await sleep(1000);
+  }
+
+  private _clearSilentDisconnectTimer(): void {
+    if (this._silentDisconnectTimer !== null) {
+      clearTimeout(this._silentDisconnectTimer);
+      this._silentDisconnectTimer = null;
+    }
   }
 
   /**

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -75,6 +75,9 @@ export interface TaskHubGrpcWorkerOptions {
    * Health pings reset this deadline. Defaults to 120000 (2 minutes).
    * Non-positive values disable detection; oversized finite values are clamped to the
    * largest safe Node.js timer delay.
+   *
+   * Set this to 0 when connecting to a sidecar that does not emit health-ping work items;
+   * otherwise an idle but healthy stream will be treated as silent.
    */
   silentDisconnectTimeoutMs?: number;
   /**
@@ -512,9 +515,13 @@ export class TaskHubGrpcWorker {
           WorkerLogs.channelRecreating(this._logger, consecutiveChannelFailures);
           const previousStub = client.stub;
           try {
+            const recreatedChannelOptions = {
+              ...this._grpcChannelOptions,
+              "grpc.use_local_subchannel_pool": 1,
+            };
             client = new GrpcClient(
               this._hostAddress,
-              this._grpcChannelOptions,
+              recreatedChannelOptions,
               this._tls,
               this._grpcChannelCredentials,
             );

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -42,8 +42,15 @@ import {
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30000;
 /** Default maximum silence between work-item stream messages. */
 const DEFAULT_SILENT_DISCONNECT_TIMEOUT_MS = 120000;
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const DEFAULT_CHANNEL_RECREATE_FAILURE_THRESHOLD = 5;
+const DEFERRED_STUB_CLOSE_DELAY_MS = 30000;
+const MAX_TIMER_DELAY_MS = 2_147_483_646;
 const HELLO_TIMEOUT_MS = 30000;
+
+type WorkItemStreamResult = {
+  outcome: "shutdown" | "silentDisconnect" | "gracefulDrain";
+  firstMessageObserved: boolean;
+};
 
 /**
  * Options for creating a TaskHubGrpcWorker.
@@ -66,9 +73,15 @@ export interface TaskHubGrpcWorkerOptions {
   /**
    * Maximum time in milliseconds between work-item stream messages before reconnecting.
    * Health pings reset this deadline. Defaults to 120000 (2 minutes).
-   * Must be a positive finite number no greater than 2147483647.
+   * Non-positive values disable detection; oversized finite values are clamped to the
+   * largest safe Node.js timer delay.
    */
   silentDisconnectTimeoutMs?: number;
+  /**
+   * Consecutive likely-poisoned failures allowed before recreating the gRPC channel.
+   * Defaults to 5. Non-positive values disable channel recreation. Must be a safe integer.
+   */
+  channelRecreateFailureThreshold?: number;
   /** Optional versioning options for filtering orchestrations by version. */
   versioning?: VersioningOptions;
   /**
@@ -97,10 +110,13 @@ export class TaskHubGrpcWorker {
   private _shutdownTimeoutMs: number;
   private _silentDisconnectTimeoutMs: number;
   private _silentDisconnectTimer: ReturnType<typeof setTimeout> | null;
+  private _channelRecreateFailureThreshold: number;
   private _backoff: ExponentialBackoff;
   private _versioning?: VersioningOptions;
   private _workItemFilters?: WorkItemFilters | "auto";
   private _abortController: AbortController | null;
+  private _workerLoopPromise: Promise<void> | null;
+  private _deferredStubCloseTimers: Map<stubs.TaskHubSidecarServiceClient, ReturnType<typeof setTimeout>>;
 
   /**
    * Creates a new TaskHubGrpcWorker instance.
@@ -148,6 +164,7 @@ export class TaskHubGrpcWorker {
     let resolvedLogger: Logger | undefined;
     let resolvedShutdownTimeoutMs: number | undefined;
     let resolvedSilentDisconnectTimeoutMs: number | undefined;
+    let resolvedChannelRecreateFailureThreshold: number | undefined;
     let resolvedVersioning: VersioningOptions | undefined;
     let resolvedWorkItemFilters: WorkItemFilters | "auto" | undefined;
 
@@ -161,6 +178,7 @@ export class TaskHubGrpcWorker {
       resolvedLogger = hostAddressOrOptions.logger;
       resolvedShutdownTimeoutMs = hostAddressOrOptions.shutdownTimeoutMs;
       resolvedSilentDisconnectTimeoutMs = hostAddressOrOptions.silentDisconnectTimeoutMs;
+      resolvedChannelRecreateFailureThreshold = hostAddressOrOptions.channelRecreateFailureThreshold;
       resolvedVersioning = hostAddressOrOptions.versioning;
       resolvedWorkItemFilters = hostAddressOrOptions.workItemFilters;
     } else {
@@ -188,26 +206,30 @@ export class TaskHubGrpcWorker {
     this._pendingWorkItems = new Set();
     this._shutdownTimeoutMs = resolvedShutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
     const silentDisconnectTimeoutMs = resolvedSilentDisconnectTimeoutMs ?? DEFAULT_SILENT_DISCONNECT_TIMEOUT_MS;
-    if (!Number.isFinite(silentDisconnectTimeoutMs) || silentDisconnectTimeoutMs <= 0) {
-      throw new RangeError(
-        `silentDisconnectTimeoutMs must be a positive finite number, got ${silentDisconnectTimeoutMs}`,
-      );
+    if (!Number.isFinite(silentDisconnectTimeoutMs)) {
+      throw new RangeError(`silentDisconnectTimeoutMs must be a finite number, got ${silentDisconnectTimeoutMs}`);
     }
-    if (silentDisconnectTimeoutMs > MAX_TIMER_DELAY_MS) {
-      throw new RangeError(
-        `silentDisconnectTimeoutMs must be no greater than ${MAX_TIMER_DELAY_MS}, got ${silentDisconnectTimeoutMs}`,
-      );
-    }
-    this._silentDisconnectTimeoutMs = silentDisconnectTimeoutMs;
+    this._silentDisconnectTimeoutMs = Math.min(silentDisconnectTimeoutMs, MAX_TIMER_DELAY_MS);
     this._silentDisconnectTimer = null;
+    const channelRecreateFailureThreshold =
+      resolvedChannelRecreateFailureThreshold ?? DEFAULT_CHANNEL_RECREATE_FAILURE_THRESHOLD;
+    if (!Number.isSafeInteger(channelRecreateFailureThreshold)) {
+      throw new RangeError(
+        `channelRecreateFailureThreshold must be a safe integer, got ${channelRecreateFailureThreshold}`,
+      );
+    }
+    this._channelRecreateFailureThreshold = channelRecreateFailureThreshold;
     this._backoff = new ExponentialBackoff({
       initialDelayMs: 1000,
       maxDelayMs: 30000,
       multiplier: 2,
+      jitterStrategy: "full",
     });
     this._versioning = resolvedVersioning;
     this._workItemFilters = resolvedWorkItemFilters;
     this._abortController = null;
+    this._workerLoopPromise = null;
+    this._deferredStubCloseTimers = new Map();
   }
 
   /**
@@ -218,49 +240,6 @@ export class TaskHubGrpcWorker {
       return await this._metadataGenerator();
     }
     return new grpc.Metadata();
-  }
-
-  /**
-   * Creates a new gRPC client and retries the worker.
-   * Properly closes the old client to prevent connection leaks.
-   */
-  private async _createNewClientAndRetry(signal?: AbortSignal): Promise<void> {
-    if (signal?.aborted) {
-      return;
-    }
-
-    // Close the old stub to prevent connection leaks
-    if (this._stub) {
-      this._stub.close();
-    }
-
-    try {
-      await this._backoff.wait(signal);
-    } catch (err) {
-      if (signal?.aborted) {
-        return;
-      }
-      throw err;
-    }
-
-    if (signal?.aborted) {
-      return;
-    }
-
-    const newClient = new GrpcClient(
-      this._hostAddress,
-      this._grpcChannelOptions,
-      this._tls,
-      this._grpcChannelCredentials,
-    );
-    this._stub = newClient.stub;
-
-    // Do not await - run in background
-    this.internalRunWorker(newClient, signal).catch((err) => {
-      if (!signal?.aborted && !this._stopWorker) {
-        WorkerLogs.workerError(this._logger, err);
-      }
-    });
   }
 
   /**
@@ -439,45 +418,166 @@ export class TaskHubGrpcWorker {
     const client = new GrpcClient(this._hostAddress, this._grpcChannelOptions, this._tls, this._grpcChannelCredentials);
     this._stub = client.stub;
 
-    // Run in background but catch any unhandled errors to prevent unhandled rejections
-    this.internalRunWorker(client, abortController.signal).catch((err) => {
-      // Only log if the worker wasn't stopped intentionally
-      if (!abortController.signal.aborted) {
-        WorkerLogs.workerError(this._logger, err);
-      }
-    });
+    const workerLoopPromise = this.internalRunWorker(client, abortController.signal);
+    this._workerLoopPromise = workerLoopPromise;
+    workerLoopPromise
+      .catch((err) => {
+        // Only log if the worker wasn't stopped intentionally
+        if (!abortController.signal.aborted) {
+          WorkerLogs.workerError(this._logger, err);
+        }
+      })
+      .finally(() => {
+        if (this._workerLoopPromise === workerLoopPromise) {
+          this._workerLoopPromise = null;
+        }
+      });
 
     this._isRunning = true;
   }
 
-  async internalRunWorker(client: GrpcClient, signal?: AbortSignal): Promise<void> {
-    try {
-      // send a "Hello" message to the sidecar to ensure that it's listening
-      await callWithMetadata(
-        (request, metadata, callback) =>
-          client.stub.hello(request, metadata, { deadline: new Date(Date.now() + HELLO_TIMEOUT_MS) }, callback),
-        new Empty(),
-        this._metadataGenerator,
-        signal,
-      );
+  async internalRunWorker(initialClient: GrpcClient, signal?: AbortSignal): Promise<void> {
+    let client = initialClient;
+    let consecutiveChannelFailures = 0;
 
-      // Reset backoff on successful connection
-      this._backoff.reset();
+    while (!signal?.aborted && !this._stopWorker) {
+      let channelLikelyPoisoned = false;
+      let streamEstablished = false;
+      let retryStream = false;
 
-      // Stream work items from the sidecar (pass metadata for insecure connections)
-      const metadata = await this._getMetadata();
-      if (signal?.aborted) {
-        return;
+      try {
+        await callWithMetadata(
+          (request, metadata, callback) =>
+            client.stub.hello(request, metadata, { deadline: new Date(Date.now() + HELLO_TIMEOUT_MS) }, callback),
+          new Empty(),
+          this._metadataGenerator,
+          signal,
+        );
+
+        const metadata = await this._getMetadata();
+        if (signal?.aborted || this._stopWorker) {
+          return;
+        }
+
+        const stream = client.stub.getWorkItems(this._buildGetWorkItemsRequest(), metadata);
+        streamEstablished = true;
+        this._responseStream = stream;
+        WorkerLogs.workerConnected(this._logger, this._hostAddress ?? "localhost:4001");
+
+        const result = await this._consumeWorkItemStream(stream, client.stub, signal, () => {
+          consecutiveChannelFailures = 0;
+          this._backoff.reset();
+        });
+        if (result.outcome === "shutdown") {
+          return;
+        }
+
+        if (result.outcome === "silentDisconnect") {
+          WorkerLogs.streamTimeout(this._logger, this._silentDisconnectTimeoutMs);
+        } else {
+          WorkerLogs.streamEnded(this._logger);
+        }
+        retryStream = true;
+        channelLikelyPoisoned =
+          result.outcome === "silentDisconnect" || (result.outcome === "gracefulDrain" && !result.firstMessageObserved);
+      } catch (err) {
+        if (signal?.aborted || this._stopWorker) {
+          return;
+        }
+
+        const error = err instanceof Error ? err : new Error(String(err));
+        const status = this._getGrpcStatus(error);
+        if (streamEstablished) {
+          WorkerLogs.streamErrorInfo(this._logger, error);
+          retryStream = true;
+        } else {
+          WorkerLogs.streamError(this._logger, error);
+        }
+
+        if (status === grpc.status.UNAVAILABLE || status === grpc.status.DEADLINE_EXCEEDED) {
+          channelLikelyPoisoned = true;
+        }
+        if (status === grpc.status.UNAUTHENTICATED) {
+          consecutiveChannelFailures = 0;
+          this._backoff.reset();
+        }
       }
-      const request = this._buildGetWorkItemsRequest();
 
-      const stream = client.stub.getWorkItems(request, metadata);
-      this._responseStream = stream;
+      if (channelLikelyPoisoned) {
+        consecutiveChannelFailures++;
+        if (
+          this._channelRecreateFailureThreshold > 0 &&
+          consecutiveChannelFailures >= this._channelRecreateFailureThreshold
+        ) {
+          WorkerLogs.channelRecreating(this._logger, consecutiveChannelFailures);
+          const previousStub = client.stub;
+          try {
+            client = new GrpcClient(
+              this._hostAddress,
+              this._grpcChannelOptions,
+              this._tls,
+              this._grpcChannelCredentials,
+            );
+          } catch (err) {
+            WorkerLogs.workerError(this._logger, err);
+            consecutiveChannelFailures = 0;
+            this._backoff.reset();
+            continue;
+          }
+          this._stub = client.stub;
+          WorkerLogs.channelRecreated(this._logger, this._hostAddress ?? "localhost:4001");
+          consecutiveChannelFailures = 0;
+          this._backoff.reset();
+          this._deferStubClose(previousStub);
+          continue;
+        }
+      }
 
-      WorkerLogs.workerConnected(this._logger, this._hostAddress ?? "localhost:4001");
+      try {
+        await this._backoff.wait(signal, (delayMs) => {
+          if (retryStream) {
+            WorkerLogs.streamRetry(this._logger, delayMs);
+          } else {
+            WorkerLogs.connectionRetry(this._logger, delayMs);
+          }
+        });
+      } catch (err) {
+        if (signal?.aborted || this._stopWorker) {
+          return;
+        }
+        throw err;
+      }
+    }
+  }
 
+  private _deferStubClose(stub: stubs.TaskHubSidecarServiceClient): void {
+    const timer = setTimeout(() => {
+      this._deferredStubCloseTimers.delete(stub);
+      stub.close();
+    }, DEFERRED_STUB_CLOSE_DELAY_MS);
+    timer.unref();
+    this._deferredStubCloseTimers.set(stub, timer);
+  }
+
+  private _closeDeferredStubs(): void {
+    for (const [stub, timer] of this._deferredStubCloseTimers) {
+      clearTimeout(timer);
+      stub.close();
+    }
+    this._deferredStubCloseTimers.clear();
+  }
+
+  private _consumeWorkItemStream(
+    stream: grpc.ClientReadableStream<pb.WorkItem>,
+    stub: stubs.TaskHubSidecarServiceClient,
+    signal: AbortSignal | undefined,
+    onFirstMessage: () => void,
+  ): Promise<WorkItemStreamResult> {
+    return new Promise<WorkItemStreamResult>((resolve, reject) => {
       let silentDisconnectTimer: ReturnType<typeof setTimeout> | undefined;
       let streamTerminated = false;
+      let firstMessageObserved = false;
+
       const clearSilentDisconnectTimer = () => {
         if (silentDisconnectTimer !== undefined) {
           clearTimeout(silentDisconnectTimer);
@@ -487,109 +587,107 @@ export class TaskHubGrpcWorker {
           silentDisconnectTimer = undefined;
         }
       };
-      const terminateStream = (reconnect: boolean, cancel: boolean) => {
+
+      const finish = (result: WorkItemStreamResult | undefined, error: Error | undefined, cancelStream: boolean) => {
         if (streamTerminated) {
           return;
         }
         streamTerminated = true;
         clearSilentDisconnectTimer();
+        signal?.removeEventListener("abort", onAbort);
         if (this._responseStream === stream) {
           this._responseStream = null;
         }
         stream.removeAllListeners();
-        stream.on("error", () => {}); // Prevent unhandled stale errors after cleanup.
-        if (cancel) {
+        stream.on("error", () => {});
+        if (cancelStream) {
           stream.cancel();
         }
-        stream.destroy();
+        if (result?.outcome !== "shutdown") {
+          stream.destroy();
+        }
 
-        if (reconnect && !signal?.aborted && !this._stopWorker) {
-          WorkerLogs.streamRetry(this._logger, this._backoff.peekNextDelay());
-          this._createNewClientAndRetry(signal).catch((retryErr) => {
-            if (!signal?.aborted && !this._stopWorker) {
-              WorkerLogs.workerError(this._logger, retryErr instanceof Error ? retryErr : new Error(String(retryErr)));
-            }
-          });
+        if (error) {
+          reject(error);
+        } else if (result) {
+          resolve(result);
         }
       };
+
       const armSilentDisconnectTimer = () => {
+        if (this._silentDisconnectTimeoutMs <= 0) {
+          return;
+        }
         clearSilentDisconnectTimer();
         const timer = setTimeout(() => {
           if (silentDisconnectTimer !== timer) {
             return;
           }
-          clearSilentDisconnectTimer();
-          terminateStream(true, true);
+          finish({ outcome: "silentDisconnect", firstMessageObserved }, undefined, true);
         }, this._silentDisconnectTimeoutMs);
         silentDisconnectTimer = timer;
         this._silentDisconnectTimer = timer;
         timer.unref();
       };
 
-      // Wait for a work item to be received
+      const onAbort = () => {
+        finish({ outcome: "shutdown", firstMessageObserved }, undefined, false);
+      };
+
       stream.on("data", (workItem: pb.WorkItem) => {
         if (streamTerminated || signal?.aborted || this._stopWorker) {
           return;
         }
         armSilentDisconnectTimer();
-        const completionToken = workItem.getCompletiontoken();
-        if (workItem.hasOrchestratorrequest()) {
-          WorkerLogs.workItemReceived(
-            this._logger,
-            "Orchestrator Request",
-            workItem?.getOrchestratorrequest()?.getInstanceid(),
-          );
-          this._executeOrchestrator(workItem.getOrchestratorrequest() as any, completionToken, client.stub);
-        } else if (workItem.hasActivityrequest()) {
-          WorkerLogs.workItemReceived(this._logger, "Activity Request");
-          this._executeActivity(workItem.getActivityrequest() as any, completionToken, client.stub);
-        } else if (workItem.hasEntityrequest()) {
-          const entityRequest = workItem.getEntityrequest() as pb.EntityBatchRequest;
-          WorkerLogs.entityRequestReceived(this._logger, entityRequest.getInstanceid(), "Entity Request");
-          this._executeEntity(entityRequest, completionToken, client.stub);
-        } else if (workItem.hasEntityrequestv2()) {
-          const entityRequestV2 = workItem.getEntityrequestv2() as pb.EntityRequest;
-          WorkerLogs.entityRequestReceived(this._logger, entityRequestV2.getInstanceid(), "Entity Request V2");
-          this._executeEntityV2(entityRequestV2, completionToken, client.stub);
-        } else if (workItem.hasHealthping()) {
-          // Health ping - no-op, just a keep-alive message from the server
-        } else {
-          WorkerLogs.unknownWorkItem(this._logger);
+        if (!firstMessageObserved) {
+          firstMessageObserved = true;
+          onFirstMessage();
         }
+        this._dispatchWorkItem(workItem, stub);
       });
-
-      // Wait for the stream to end or error
       stream.on("end", () => {
-        if (signal?.aborted || this._stopWorker) {
-          WorkerLogs.streamEnded(this._logger);
-          terminateStream(false, false);
-          return;
-        }
-        terminateStream(true, false);
+        finish({ outcome: "gracefulDrain", firstMessageObserved }, undefined, false);
       });
-
       stream.on("error", (err: Error) => {
-        // Ignore cancellation errors when the worker is being stopped intentionally
         if (signal?.aborted || this._stopWorker) {
-          clearSilentDisconnectTimer();
+          finish({ outcome: "shutdown", firstMessageObserved }, undefined, false);
           return;
         }
-        WorkerLogs.streamErrorInfo(this._logger, err);
-        terminateStream(true, false);
+        finish(undefined, err, false);
       });
-
+      signal?.addEventListener("abort", onAbort, { once: true });
       armSilentDisconnectTimer();
-    } catch (err) {
-      if (signal?.aborted || this._stopWorker) {
-        // ignoring the error because the worker has been stopped
-        return;
-      }
-      const error = err instanceof Error ? err : new Error(String(err));
-      WorkerLogs.streamError(this._logger, error);
-      WorkerLogs.connectionRetry(this._logger, this._backoff.peekNextDelay());
-      await this._createNewClientAndRetry(signal);
-      return;
+    });
+  }
+
+  private _dispatchWorkItem(workItem: pb.WorkItem, stub: stubs.TaskHubSidecarServiceClient): void {
+    const completionToken = workItem.getCompletiontoken();
+    if (workItem.hasOrchestratorrequest()) {
+      WorkerLogs.workItemReceived(
+        this._logger,
+        "Orchestrator Request",
+        workItem.getOrchestratorrequest()?.getInstanceid(),
+      );
+      this._executeOrchestrator(workItem.getOrchestratorrequest() as pb.OrchestratorRequest, completionToken, stub);
+    } else if (workItem.hasActivityrequest()) {
+      WorkerLogs.workItemReceived(this._logger, "Activity Request");
+      this._executeActivity(workItem.getActivityrequest() as pb.ActivityRequest, completionToken, stub);
+    } else if (workItem.hasEntityrequest()) {
+      const entityRequest = workItem.getEntityrequest() as pb.EntityBatchRequest;
+      WorkerLogs.entityRequestReceived(this._logger, entityRequest.getInstanceid(), "Entity Request");
+      this._executeEntity(entityRequest, completionToken, stub);
+    } else if (workItem.hasEntityrequestv2()) {
+      const entityRequestV2 = workItem.getEntityrequestv2() as pb.EntityRequest;
+      WorkerLogs.entityRequestReceived(this._logger, entityRequestV2.getInstanceid(), "Entity Request V2");
+      this._executeEntityV2(entityRequestV2, completionToken, stub);
+    } else if (!workItem.hasHealthping()) {
+      WorkerLogs.unknownWorkItem(this._logger);
     }
+  }
+
+  private _getGrpcStatus(error: Error): grpc.status | undefined {
+    const code = (error as Partial<grpc.ServiceError>).code;
+    return typeof code === "number" ? code : undefined;
   }
 
   /**
@@ -606,25 +704,20 @@ export class TaskHubGrpcWorker {
     this._abortController?.abort();
     this._clearSilentDisconnectTimer();
 
-    // Cancel stream first while error handlers are still attached
-    // This allows the error handler to suppress CANCELLED errors
+    const streamClosed = responseStream
+      ? new Promise<void>((resolve) => {
+          responseStream.once("end", resolve);
+          responseStream.once("close", resolve);
+          responseStream.once("error", () => resolve());
+        })
+      : undefined;
     responseStream?.cancel();
 
     // Wait for the stream to react to cancellation using events rather than a fixed delay.
     // This avoids race conditions caused by relying on timing alone.
-    if (responseStream) {
+    if (streamClosed) {
       try {
-        await withTimeout(
-          new Promise<void>((resolve) => {
-            const stream = responseStream;
-            // Any of these events indicates the stream has processed cancellation / is closing.
-            stream.once("end", resolve);
-            stream.once("close", resolve);
-            stream.once("error", () => resolve());
-          }),
-          1000,
-          "Timed out waiting for response stream to close after cancellation",
-        );
+        await withTimeout(streamClosed, 1000, "Timed out waiting for response stream to close after cancellation");
       } catch {
         // If we time out waiting for the stream to close, proceed with forced cleanup below.
       }
@@ -653,6 +746,7 @@ export class TaskHubGrpcWorker {
       }
     }
 
+    this._closeDeferredStubs();
     if (this._stub) {
       // Close the gRPC client - this is a synchronous operation
       this._stub.close();

--- a/packages/durabletask-js/test/backoff.spec.ts
+++ b/packages/durabletask-js/test/backoff.spec.ts
@@ -104,6 +104,26 @@ describe("ExponentialBackoff", () => {
         jest.useRealTimers();
       }
     });
+
+    it("reports the exact jittered delay used for the wait", async () => {
+      jest.useFakeTimers();
+      jest.spyOn(Math, "random").mockReturnValue(0.25);
+      const backoff = new ExponentialBackoff({
+        initialDelayMs: 1000,
+        jitterStrategy: "full",
+      });
+      const delays: number[] = [];
+
+      try {
+        const waitPromise = backoff.wait(undefined, (delayMs) => delays.push(delayMs));
+        await jest.advanceTimersByTimeAsync(250);
+        await waitPromise;
+
+        expect(delays).toEqual([250]);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe("reset", () => {
@@ -144,6 +164,19 @@ describe("ExponentialBackoff", () => {
   });
 
   describe("jitter", () => {
+    it("supports full jitter from zero to the exponential upper bound", () => {
+      const random = jest.spyOn(Math, "random").mockReturnValue(0.25);
+      const backoff = new ExponentialBackoff({
+        initialDelayMs: 1000,
+        maxDelayMs: 30000,
+        jitterStrategy: "full",
+      });
+
+      expect(backoff.peekNextDelay()).toBe(250);
+
+      random.mockRestore();
+    });
+
     it("should apply jitter within expected range", () => {
       const backoff = new ExponentialBackoff({
         initialDelayMs: 100,

--- a/packages/durabletask-js/test/worker-startup.spec.ts
+++ b/packages/durabletask-js/test/worker-startup.spec.ts
@@ -2,25 +2,108 @@
 // Licensed under the MIT License.
 
 import * as grpc from "@grpc/grpc-js";
+import { EventEmitter } from "events";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { GrpcClient } from "../src/client/client-grpc";
+import * as pb from "../src/proto/orchestrator_service_pb";
 import * as stubs from "../src/proto/orchestrator_service_grpc_pb";
-import { Logger, NoOpLogger } from "../src/types/logger.type";
-import { TaskHubGrpcWorker } from "../src/worker/task-hub-grpc-worker";
+import { Logger, NoOpLogger, StructuredLogger } from "../src/types/logger.type";
+import {
+  EVENT_CHANNEL_RECREATED,
+  EVENT_CHANNEL_RECREATING,
+  EVENT_STREAM_ENDED,
+  EVENT_STREAM_TIMEOUT,
+} from "../src/worker/logs";
+import { TaskHubGrpcWorker, TaskHubGrpcWorkerOptions } from "../src/worker/task-hub-grpc-worker";
 
 type HelloCallback = (error: grpc.ServiceError | null, response: Empty) => void;
+type MockStream = EventEmitter & { cancel: jest.Mock; destroy: jest.Mock };
+type MockStub = stubs.TaskHubSidecarServiceClient & {
+  hello: jest.Mock;
+  getWorkItems: jest.Mock;
+  close: jest.Mock;
+};
 
-function useStub(hello: jest.Mock): jest.SpyInstance {
+function grpcError(code: grpc.status, message = "gRPC failure"): grpc.ServiceError {
+  return Object.assign(new Error(message), {
+    code,
+    details: message,
+    metadata: new grpc.Metadata(),
+  });
+}
+
+function createHealthPing(): pb.WorkItem {
+  const workItem = new pb.WorkItem();
+  workItem.setHealthping(new pb.HealthPing());
+  return workItem;
+}
+
+function createMockStream(closeSynchronously = false): MockStream {
+  const stream = new EventEmitter() as MockStream;
+  stream.cancel = jest.fn(() => {
+    if (closeSynchronously) {
+      stream.emit("close");
+    } else {
+      setTimeout(() => stream.emit("close"), 0);
+    }
+  });
+  stream.destroy = jest.fn();
+  return stream;
+}
+
+function createUnaryCall(cancel = jest.fn()): grpc.ClientUnaryCall {
+  return Object.assign(new EventEmitter(), {
+    cancel,
+    getPeer: () => "mock-peer",
+    getAuthContext: () => null,
+  });
+}
+
+function createStub(
+  streams: MockStream[],
+  helloStatuses: Array<grpc.status | null> = [],
+  closeSynchronously = false,
+): MockStub {
+  let helloCall = 0;
   const stub = {
-    hello,
-    getWorkItems: jest.fn(),
+    hello: jest.fn((...args: any[]) => {
+      const status = helloStatuses[helloCall++];
+      const error = status === undefined || status === null ? null : grpcError(status);
+      (args.at(-1) as HelloCallback)(error, new Empty());
+      return createUnaryCall();
+    }),
+    getWorkItems: jest.fn(() => {
+      const stream = createMockStream(closeSynchronously);
+      streams.push(stream);
+      return stream;
+    }),
     close: jest.fn(),
-  } as unknown as stubs.TaskHubSidecarServiceClient;
+  };
+  return stub as unknown as MockStub;
+}
+
+function useStub(stub: MockStub): jest.SpyInstance {
   return jest.spyOn(GrpcClient.prototype as any, "_generateClient").mockReturnValue(stub);
 }
 
-function getCallback(args: any[]): HelloCallback {
-  return args[args.length - 1] as HelloCallback;
+function useNewStubPerClient(streams: MockStream[], stubsCreated: MockStub[]): jest.SpyInstance {
+  return jest.spyOn(GrpcClient.prototype as any, "_generateClient").mockImplementation(() => {
+    const stub = createStub(streams);
+    stubsCreated.push(stub);
+    return stub;
+  });
+}
+
+function createCapturingLogger(): { logger: StructuredLogger; eventIds: number[] } {
+  const eventIds: number[] = [];
+  const logger = {
+    logEvent: (_level, event) => eventIds.push(event.eventId),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  } satisfies StructuredLogger;
+  return { logger, eventIds };
 }
 
 async function flushPromises(): Promise<void> {
@@ -29,10 +112,30 @@ async function flushPromises(): Promise<void> {
   }
 }
 
+async function failStream(stream: MockStream, code = grpc.status.UNAVAILABLE): Promise<void> {
+  stream.emit("error", grpcError(code));
+  await jest.advanceTimersByTimeAsync(0);
+  await flushPromises();
+}
+
 async function stopWorker(worker: TaskHubGrpcWorker): Promise<void> {
   const stop = worker.stop();
   await jest.advanceTimersByTimeAsync(1000);
   await stop;
+}
+
+async function startWorker(
+  stub: MockStub,
+  options: TaskHubGrpcWorkerOptions = {},
+  installStub = true,
+): Promise<TaskHubGrpcWorker> {
+  if (installStub) {
+    useStub(stub);
+  }
+  const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger(), ...options });
+  await worker.start();
+  await flushPromises();
+  return worker;
 }
 
 describe("TaskHubGrpcWorker startup", () => {
@@ -45,47 +148,345 @@ describe("TaskHubGrpcWorker startup", () => {
     jest.restoreAllMocks();
   });
 
+  it("uses full jitter for reconnect backoff", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.25);
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+
+    expect((worker as any)._backoff.peekNextDelay()).toBe(250);
+  });
+
+  it("reuses the same gRPC client before five consecutive poisoned failures", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams);
+    const generateClient = useStub(stub);
+    const worker = await startWorker(stub, {}, false);
+
+    for (let failure = 0; failure < 4; failure++) {
+      await failStream(streams[failure]);
+    }
+
+    expect(generateClient).toHaveBeenCalledTimes(1);
+    expect(stub.getWorkItems).toHaveBeenCalledTimes(5);
+    await stopWorker(worker);
+  });
+
+  it("recreates the gRPC client after five consecutive poisoned failures", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const { logger, eventIds } = createCapturingLogger();
+    const streams: MockStream[] = [];
+    const stubsCreated: MockStub[] = [];
+    const generateClient = useNewStubPerClient(streams, stubsCreated);
+    const worker = new TaskHubGrpcWorker({ logger });
+
+    await worker.start();
+    await flushPromises();
+    for (let failure = 0; failure < 5; failure++) {
+      await failStream(streams[failure]);
+    }
+
+    expect(generateClient).toHaveBeenCalledTimes(2);
+    expect(stubsCreated[0].getWorkItems).toHaveBeenCalledTimes(5);
+    expect(stubsCreated[1].getWorkItems).toHaveBeenCalledTimes(1);
+    expect(stubsCreated[0].close).not.toHaveBeenCalled();
+    expect(eventIds).toContain(EVENT_CHANNEL_RECREATING);
+    expect(eventIds).toContain(EVENT_CHANNEL_RECREATED);
+
+    await jest.advanceTimersByTimeAsync(29999);
+    expect(stubsCreated[0].close).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1);
+    expect(stubsCreated[0].close).toHaveBeenCalledTimes(1);
+    await stopWorker(worker);
+  });
+
+  it("closes deferred gRPC clients during shutdown", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stubsCreated: MockStub[] = [];
+    useNewStubPerClient(streams, stubsCreated);
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      channelRecreateFailureThreshold: 1,
+    });
+
+    await worker.start();
+    await flushPromises();
+    await failStream(streams[0]);
+    expect(stubsCreated[0].close).not.toHaveBeenCalled();
+
+    await stopWorker(worker);
+
+    expect(stubsCreated[0].close).toHaveBeenCalledTimes(1);
+    expect(stubsCreated[1].close).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("keeps using the existing channel when recreation fails", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams);
+    jest
+      .spyOn(GrpcClient.prototype as any, "_generateClient")
+      .mockReturnValueOnce(stub)
+      .mockImplementationOnce(() => {
+        throw new Error("channel recreation failed");
+      });
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      channelRecreateFailureThreshold: 1,
+    });
+
+    await worker.start();
+    await flushPromises();
+    await failStream(streams[0]);
+
+    expect(stub.getWorkItems).toHaveBeenCalledTimes(2);
+    expect(stub.close).not.toHaveBeenCalled();
+    await stopWorker(worker);
+  });
+
+  it("disables channel recreation for a non-positive threshold", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams);
+    const generateClient = useStub(stub);
+    const worker = await startWorker(stub, { channelRecreateFailureThreshold: 0 }, false);
+
+    for (let failure = 0; failure < 6; failure++) {
+      await failStream(streams[failure]);
+    }
+
+    expect(generateClient).toHaveBeenCalledTimes(1);
+    expect(stub.getWorkItems).toHaveBeenCalledTimes(7);
+    await stopWorker(worker);
+  });
+
+  it.each([1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects an invalid channel recreation threshold (%s)",
+    (channelRecreateFailureThreshold) => {
+      expect(
+        () =>
+          new TaskHubGrpcWorker({
+            logger: new NoOpLogger(),
+            channelRecreateFailureThreshold,
+          }),
+      ).toThrow("channelRecreateFailureThreshold must be a safe integer");
+    },
+  );
+
+  it("resets poisoned channel failures after the first stream message", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams);
+    const generateClient = useStub(stub);
+    const worker = await startWorker(stub, { channelRecreateFailureThreshold: 2 }, false);
+
+    await failStream(streams[0]);
+    streams[1].emit("data", createHealthPing());
+    await failStream(streams[1]);
+
+    expect(generateClient).toHaveBeenCalledTimes(1);
+    expect(stub.getWorkItems).toHaveBeenCalledTimes(3);
+    await stopWorker(worker);
+  });
+
+  it("reconnects without recreating the channel after a non-empty graceful drain", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams);
+    const generateClient = useStub(stub);
+    const worker = await startWorker(stub, { channelRecreateFailureThreshold: 1 }, false);
+
+    streams[0].emit("data", createHealthPing());
+    streams[0].emit("end");
+    await jest.advanceTimersByTimeAsync(0);
+    await flushPromises();
+
+    expect(generateClient).toHaveBeenCalledTimes(1);
+    expect(stub.getWorkItems).toHaveBeenCalledTimes(2);
+    await stopWorker(worker);
+  });
+
+  it("counts an empty graceful drain as a poisoned channel failure", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stubsCreated: MockStub[] = [];
+    const generateClient = useNewStubPerClient(streams, stubsCreated);
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      channelRecreateFailureThreshold: 1,
+    });
+
+    await worker.start();
+    await flushPromises();
+    streams[0].emit("end");
+    await jest.advanceTimersByTimeAsync(0);
+    await flushPromises();
+
+    expect(generateClient).toHaveBeenCalledTimes(2);
+    await stopWorker(worker);
+  });
+
+  it("counts a silent disconnect as a poisoned channel failure", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stubsCreated: MockStub[] = [];
+    const generateClient = useNewStubPerClient(streams, stubsCreated);
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs: 100,
+      channelRecreateFailureThreshold: 1,
+    });
+
+    await worker.start();
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(100);
+    await flushPromises();
+
+    expect(streams[0].cancel).toHaveBeenCalledTimes(1);
+    expect(generateClient).toHaveBeenCalledTimes(2);
+    await stopWorker(worker);
+  });
+
+  it("logs a silent disconnect distinctly from a graceful drain", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const { logger, eventIds } = createCapturingLogger();
+    const streams: MockStream[] = [];
+    const stub = createStub(streams);
+    useStub(stub);
+    const worker = new TaskHubGrpcWorker({
+      logger,
+      silentDisconnectTimeoutMs: 100,
+    });
+
+    await worker.start();
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(100);
+    await flushPromises();
+
+    expect(eventIds).toContain(EVENT_STREAM_TIMEOUT);
+    expect(eventIds).not.toContain(EVENT_STREAM_ENDED);
+    await stopWorker(worker);
+  });
+
+  it.each([grpc.status.CANCELLED, grpc.status.UNAUTHENTICATED, grpc.status.NOT_FOUND])(
+    "does not recreate the channel for non-poisoning gRPC status %s",
+    async (status) => {
+      jest.spyOn(Math, "random").mockReturnValue(0);
+      const streams: MockStream[] = [];
+      const stub = createStub(streams, [status, null]);
+      const generateClient = useStub(stub);
+      const worker = new TaskHubGrpcWorker({
+        logger: new NoOpLogger(),
+        channelRecreateFailureThreshold: 1,
+      });
+
+      await worker.start();
+      await flushPromises();
+      await jest.advanceTimersByTimeAsync(0);
+      await flushPromises();
+
+      expect(generateClient).toHaveBeenCalledTimes(1);
+      expect(stub.getWorkItems).toHaveBeenCalledTimes(1);
+      await stopWorker(worker);
+    },
+  );
+
+  it("resets prior poisoned failures after an authentication response", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams, [
+      grpc.status.UNAVAILABLE,
+      grpc.status.UNAUTHENTICATED,
+      grpc.status.UNAVAILABLE,
+      null,
+    ]);
+    const generateClient = useStub(stub);
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      channelRecreateFailureThreshold: 2,
+    });
+
+    await worker.start();
+    await flushPromises();
+    for (let retry = 0; retry < 10; retry++) {
+      await jest.advanceTimersByTimeAsync(1);
+      await flushPromises();
+    }
+
+    expect(generateClient).toHaveBeenCalledTimes(1);
+    expect(stub.getWorkItems).toHaveBeenCalledTimes(1);
+    await stopWorker(worker);
+  });
+
+  it("resets reconnect backoff only after the first stream message", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.5);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams, [grpc.status.UNAVAILABLE, null]);
+    const worker = await startWorker(stub);
+
+    await jest.advanceTimersByTimeAsync(500);
+    await flushPromises();
+    expect((worker as any)._backoff.attemptCount).toBe(1);
+
+    streams[0].emit("data", createHealthPing());
+
+    expect((worker as any)._backoff.attemptCount).toBe(0);
+    await stopWorker(worker);
+  });
+
   it("sets a 30-second deadline on every hello and retries an initial failure", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(1);
     const deadlines: number[] = [];
     const hello = jest.fn((...args: any[]) => {
       deadlines.push((args[2] as grpc.CallOptions).deadline!.valueOf() - Date.now());
-      getCallback(args)(new Error("unavailable") as grpc.ServiceError, new Empty());
-      return { cancel: jest.fn() } as unknown as grpc.ClientUnaryCall;
+      (args.at(-1) as HelloCallback)(new Error("unavailable") as grpc.ServiceError, new Empty());
+      return createUnaryCall();
     });
+    const stub = {
+      hello,
+      getWorkItems: jest.fn(),
+      close: jest.fn(),
+    } as unknown as MockStub;
     const logger = {
       error: jest.fn(),
       warn: jest.fn(),
       info: jest.fn(),
       debug: jest.fn(),
     } satisfies Logger;
-    useStub(hello);
+    useStub(stub);
     const worker = new TaskHubGrpcWorker({ logger });
 
-    await expect(worker.start()).resolves.toBeUndefined();
+    await worker.start();
     await flushPromises();
     await jest.advanceTimersByTimeAsync(2000);
 
     expect(hello).toHaveBeenCalledTimes(2);
     expect(deadlines).toEqual([30000, 30000]);
     expect(logger.error).toHaveBeenCalled();
-
     await stopWorker(worker);
   });
 
   it("logs and retries when hello throws synchronously", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(1);
     const hello = jest
       .fn()
       .mockImplementationOnce(() => {
         throw new Error("synchronous hello failure");
       })
-      .mockImplementation(() => ({ cancel: jest.fn() }) as unknown as grpc.ClientUnaryCall);
+      .mockImplementation(() => createUnaryCall());
+    const stub = {
+      hello,
+      getWorkItems: jest.fn(),
+      close: jest.fn(),
+    } as unknown as MockStub;
     const logger = {
       error: jest.fn(),
       warn: jest.fn(),
       info: jest.fn(),
       debug: jest.fn(),
     } satisfies Logger;
-    useStub(hello);
+    useStub(stub);
     const worker = new TaskHubGrpcWorker({ logger });
 
     await worker.start();
@@ -94,30 +495,39 @@ describe("TaskHubGrpcWorker startup", () => {
 
     expect(logger.error).toHaveBeenCalled();
     expect(hello).toHaveBeenCalledTimes(2);
-
     await stopWorker(worker);
   });
 
   it("cancels a pending hello when stopped", async () => {
     const cancel = jest.fn();
-    const hello = jest.fn(() => ({ cancel }) as unknown as grpc.ClientUnaryCall);
-    useStub(hello);
-    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const stub = {
+      hello: jest.fn(() => createUnaryCall(cancel)),
+      getWorkItems: jest.fn(),
+      close: jest.fn(),
+    } as unknown as MockStub;
+    const worker = await startWorker(stub);
 
-    await worker.start();
-    await flushPromises();
     await stopWorker(worker);
 
     expect(cancel).toHaveBeenCalledTimes(1);
     expect((worker as any)._isRunning).toBe(false);
   });
 
+  it("observes a synchronous stream close during shutdown", async () => {
+    const streams: MockStream[] = [];
+    const stub = createStub(streams, [], true);
+    const worker = await startWorker(stub);
+
+    await stopWorker(worker);
+
+    expect(streams[0].cancel).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
   it("cancels reconnect backoff and prevents a stopped run from reconnecting", async () => {
-    const hello = jest.fn((...args: any[]) => {
-      getCallback(args)(new Error("unavailable") as grpc.ServiceError, new Empty());
-      return { cancel: jest.fn() } as unknown as grpc.ClientUnaryCall;
-    });
-    const generateClient = useStub(hello);
+    const streams: MockStream[] = [];
+    const stub = createStub(streams, [grpc.status.UNAVAILABLE]);
+    const generateClient = useStub(stub);
     const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
 
     await worker.start();
@@ -128,7 +538,7 @@ describe("TaskHubGrpcWorker startup", () => {
     await jest.advanceTimersByTimeAsync(60000);
 
     expect(generateClient).toHaveBeenCalledTimes(1);
-    expect(hello).toHaveBeenCalledTimes(1);
+    expect(stub.hello).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/packages/durabletask-js/test/worker-startup.spec.ts
+++ b/packages/durabletask-js/test/worker-startup.spec.ts
@@ -199,6 +199,51 @@ describe("TaskHubGrpcWorker startup", () => {
     await stopWorker(worker);
   });
 
+  it("isolates every recreated client from grpc-js's global subchannel pool", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    const streams: MockStream[] = [];
+    const stubsCreated: MockStub[] = [];
+    const originalOptions = { "grpc.keepalive_time_ms": 1234 };
+    const clientOptions: grpc.ChannelOptions[] = [];
+    const constructorSpy = jest.spyOn(GrpcClient.prototype as any, "_generateChannelOptions");
+    constructorSpy.mockImplementation((options: unknown) => {
+      const channelOptions = options as grpc.ChannelOptions;
+      clientOptions.push({ ...channelOptions });
+      return {
+        "grpc.max_receive_message_length": -1,
+        "grpc.max_send_message_length": -1,
+        "grpc.primary_user_agent": "durabletask-js",
+        ...channelOptions,
+      };
+    });
+    useNewStubPerClient(streams, stubsCreated);
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      options: originalOptions,
+      channelRecreateFailureThreshold: 1,
+    });
+
+    await worker.start();
+    await flushPromises();
+    await failStream(streams[0]);
+    await failStream(streams[1]);
+
+    expect(clientOptions).toEqual([
+      { "grpc.keepalive_time_ms": 1234 },
+      {
+        "grpc.keepalive_time_ms": 1234,
+        "grpc.use_local_subchannel_pool": 1,
+      },
+      {
+        "grpc.keepalive_time_ms": 1234,
+        "grpc.use_local_subchannel_pool": 1,
+      },
+    ]);
+    expect(originalOptions).toEqual({ "grpc.keepalive_time_ms": 1234 });
+
+    await stopWorker(worker);
+  });
+
   it("closes deferred gRPC clients during shutdown", async () => {
     jest.spyOn(Math, "random").mockReturnValue(0);
     const streams: MockStream[] = [];

--- a/packages/durabletask-js/test/worker-stream-recovery.spec.ts
+++ b/packages/durabletask-js/test/worker-stream-recovery.spec.ts
@@ -3,18 +3,17 @@
 
 /**
  * Tests that the TaskHubGrpcWorker correctly recovers when the gRPC work-item
- * stream emits an "error" event without a subsequent "end" event.
+ * stream fails explicitly or remains open without delivering messages.
  *
- * This validates the fix for a bug where the stream "error" handler only logged
- * the error but did not clean up the stream or retry the connection — causing
- * the worker to silently stop processing work items after transport-level
- * failures (e.g., UNAVAILABLE, network disconnections).
+ * This covers transport errors that omit a subsequent "end" event and half-open
+ * HTTP/2 connections that emit neither messages nor terminal events.
  */
 
 import { EventEmitter } from "events";
 import { TaskHubGrpcWorker } from "../src/worker/task-hub-grpc-worker";
 import { NoOpLogger } from "../src/types/logger.type";
 import { GrpcClient } from "../src/client/client-grpc";
+import * as pb from "../src/proto/orchestrator_service_pb";
 
 /**
  * Creates a mock GrpcClient whose `hello` call succeeds immediately
@@ -49,6 +48,167 @@ function flushAsync(): Promise<void> {
 }
 
 describe("Worker Stream Recovery", () => {
+  describe("silent stream watchdog", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+      "rejects an invalid silent disconnect timeout (%s)",
+      (silentDisconnectTimeoutMs) => {
+        expect(
+          () =>
+            new TaskHubGrpcWorker({
+              logger: new NoOpLogger(),
+              silentDisconnectTimeoutMs,
+            }),
+        ).toThrow("silentDisconnectTimeoutMs must be a positive finite number");
+      },
+    );
+
+    it("rejects a silent disconnect timeout above the Node.js timer limit", () => {
+      expect(
+        () =>
+          new TaskHubGrpcWorker({
+            logger: new NoOpLogger(),
+            silentDisconnectTimeoutMs: 2_147_483_648,
+          }),
+      ).toThrow("silentDisconnectTimeoutMs must be no greater than 2147483647");
+    });
+
+    it("accepts the maximum Node.js timer delay", () => {
+      expect(
+        () =>
+          new TaskHubGrpcWorker({
+            logger: new NoOpLogger(),
+            silentDisconnectTimeoutMs: 2_147_483_647,
+          }),
+      ).not.toThrow();
+    });
+
+    it("cancels a permanently silent stream and reconnects", async () => {
+      const worker = new TaskHubGrpcWorker({
+        logger: new NoOpLogger(),
+        silentDisconnectTimeoutMs: 100,
+      });
+      const { client, mockStream } = createMockClient();
+      const retryMock = jest.fn().mockResolvedValue(undefined);
+      (worker as any)._createNewClientAndRetry = retryMock;
+
+      await worker.internalRunWorker(client);
+      await jest.advanceTimersByTimeAsync(99);
+
+      expect(mockStream.cancel).not.toHaveBeenCalled();
+      expect(retryMock).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+
+      expect(mockStream.cancel).toHaveBeenCalledTimes(1);
+      expect(mockStream.destroy).toHaveBeenCalledTimes(1);
+      expect(retryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses a 120-second silence window by default", async () => {
+      const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+      const { client, mockStream } = createMockClient();
+      const retryMock = jest.fn().mockResolvedValue(undefined);
+      (worker as any)._createNewClientAndRetry = retryMock;
+
+      await worker.internalRunWorker(client);
+      await jest.advanceTimersByTimeAsync(119999);
+
+      expect(mockStream.cancel).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+
+      expect(mockStream.cancel).toHaveBeenCalledTimes(1);
+      expect(retryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets the deadline for every message, including health pings", async () => {
+      const worker = new TaskHubGrpcWorker({
+        logger: new NoOpLogger(),
+        silentDisconnectTimeoutMs: 100,
+      });
+      const { client, mockStream } = createMockClient();
+      const retryMock = jest.fn().mockResolvedValue(undefined);
+      (worker as any)._createNewClientAndRetry = retryMock;
+
+      await worker.internalRunWorker(client);
+      await jest.advanceTimersByTimeAsync(60);
+      mockStream.emit("data", new pb.WorkItem());
+      await jest.advanceTimersByTimeAsync(60);
+
+      expect(mockStream.cancel).not.toHaveBeenCalled();
+
+      const healthPing = new pb.WorkItem();
+      healthPing.setHealthping(new pb.HealthPing());
+      mockStream.emit("data", healthPing);
+      await jest.advanceTimersByTimeAsync(99);
+
+      expect(mockStream.cancel).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+
+      expect(mockStream.cancel).toHaveBeenCalledTimes(1);
+      expect(retryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(["error", "end"] as const)("cleans up the watchdog after a stream %s", async (event) => {
+      const worker = new TaskHubGrpcWorker({
+        logger: new NoOpLogger(),
+        silentDisconnectTimeoutMs: 100,
+      });
+      const { client, mockStream } = createMockClient();
+      const retryMock = jest.fn().mockResolvedValue(undefined);
+      (worker as any)._createNewClientAndRetry = retryMock;
+
+      await worker.internalRunWorker(client);
+      if (event === "error") {
+        mockStream.emit("error", new Error("14 UNAVAILABLE: Connection lost"));
+      } else {
+        mockStream.emit("end");
+      }
+
+      expect(retryMock).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+
+      await jest.advanceTimersByTimeAsync(100);
+
+      expect(retryMock).toHaveBeenCalledTimes(1);
+      expect(mockStream.cancel).not.toHaveBeenCalled();
+    });
+
+    it("cancels the watchdog during shutdown without reconnecting", async () => {
+      const worker = new TaskHubGrpcWorker({
+        logger: new NoOpLogger(),
+        silentDisconnectTimeoutMs: 10000,
+      });
+      const { client, mockStream } = createMockClient();
+      const retryMock = jest.fn().mockResolvedValue(undefined);
+      (worker as any)._createNewClientAndRetry = retryMock;
+      (worker as any)._isRunning = true;
+      mockStream.cancel.mockImplementation(() => {
+        setTimeout(() => mockStream.emit("close"), 0);
+      });
+
+      await worker.internalRunWorker(client);
+      const stopPromise = worker.stop();
+      await jest.advanceTimersByTimeAsync(1000);
+      await stopPromise;
+
+      expect(jest.getTimerCount()).toBe(0);
+
+      await jest.advanceTimersByTimeAsync(10000);
+
+      expect(retryMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("should retry connection after a stream error event", async () => {
     const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
     const { client, mockStream } = createMockClient();

--- a/packages/durabletask-js/test/worker-stream-recovery.spec.ts
+++ b/packages/durabletask-js/test/worker-stream-recovery.spec.ts
@@ -1,368 +1,233 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-/**
- * Tests that the TaskHubGrpcWorker correctly recovers when the gRPC work-item
- * stream fails explicitly or remains open without delivering messages.
- *
- * This covers transport errors that omit a subsequent "end" event and half-open
- * HTTP/2 connections that emit neither messages nor terminal events.
- */
-
+import * as grpc from "@grpc/grpc-js";
 import { EventEmitter } from "events";
-import { TaskHubGrpcWorker } from "../src/worker/task-hub-grpc-worker";
-import { NoOpLogger } from "../src/types/logger.type";
-import { GrpcClient } from "../src/client/client-grpc";
 import * as pb from "../src/proto/orchestrator_service_pb";
+import * as stubs from "../src/proto/orchestrator_service_grpc_pb";
+import { NoOpLogger } from "../src/types/logger.type";
+import { TaskHubGrpcWorker } from "../src/worker/task-hub-grpc-worker";
 
-/**
- * Creates a mock GrpcClient whose `hello` call succeeds immediately
- * and whose `getWorkItems` returns a controllable EventEmitter stream.
- */
-function createMockClient(): {
-  client: GrpcClient;
-  mockStream: EventEmitter & { destroy: jest.Mock; cancel: jest.Mock };
-} {
-  const mockStream = new EventEmitter() as EventEmitter & {
-    destroy: jest.Mock;
-    cancel: jest.Mock;
-  };
-  mockStream.destroy = jest.fn();
-  mockStream.cancel = jest.fn();
+type MockStream = EventEmitter & {
+  cancel: jest.Mock;
+  destroy: jest.Mock;
+};
 
-  const stub = {
-    hello: (_req: any, _metadata: any, _options: any, callback: (err: any, res: any) => void) => {
-      callback(null, {});
-      return {} as any;
-    },
-    getWorkItems: jest.fn().mockReturnValue(mockStream),
-  };
+type StreamResult = {
+  outcome: "shutdown" | "silentDisconnect" | "gracefulDrain";
+  firstMessageObserved: boolean;
+};
 
-  const client = { stub } as unknown as GrpcClient;
-  return { client, mockStream };
+function createMockStream(): MockStream {
+  const stream = new EventEmitter() as MockStream;
+  stream.cancel = jest.fn();
+  stream.destroy = jest.fn();
+  return stream;
 }
 
-/** Flush the microtask / next-tick queue so async event handlers complete. */
-function flushAsync(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
+function consumeStream(
+  worker: TaskHubGrpcWorker,
+  stream: MockStream,
+  signal?: AbortSignal,
+  onFirstMessage = jest.fn(),
+): Promise<StreamResult> {
+  return (worker as any)._consumeWorkItemStream(
+    stream as unknown as grpc.ClientReadableStream<pb.WorkItem>,
+    {} as stubs.TaskHubSidecarServiceClient,
+    signal,
+    onFirstMessage,
+  );
 }
 
 describe("Worker Stream Recovery", () => {
-  describe("silent stream watchdog", () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
 
-    afterEach(() => {
-      jest.useRealTimers();
-    });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
-    it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
-      "rejects an invalid silent disconnect timeout (%s)",
-      (silentDisconnectTimeoutMs) => {
-        expect(
-          () =>
-            new TaskHubGrpcWorker({
-              logger: new NoOpLogger(),
-              silentDisconnectTimeoutMs,
-            }),
-        ).toThrow("silentDisconnectTimeoutMs must be a positive finite number");
-      },
-    );
-
-    it("rejects a silent disconnect timeout above the Node.js timer limit", () => {
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "rejects an invalid silent disconnect timeout (%s)",
+    (silentDisconnectTimeoutMs) => {
       expect(
         () =>
           new TaskHubGrpcWorker({
             logger: new NoOpLogger(),
-            silentDisconnectTimeoutMs: 2_147_483_648,
+            silentDisconnectTimeoutMs,
           }),
-      ).toThrow("silentDisconnectTimeoutMs must be no greater than 2147483647");
+      ).toThrow("silentDisconnectTimeoutMs must be a finite number");
+    },
+  );
+
+  it.each([0, -1])("disables the watchdog for a non-positive timeout (%s)", async (silentDisconnectTimeoutMs) => {
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs,
     });
+    const stream = createMockStream();
+    const controller = new AbortController();
+    const resultPromise = consumeStream(worker, stream, controller.signal);
 
-    it("accepts the maximum Node.js timer delay", () => {
-      expect(
-        () =>
-          new TaskHubGrpcWorker({
-            logger: new NoOpLogger(),
-            silentDisconnectTimeoutMs: 2_147_483_647,
-          }),
-      ).not.toThrow();
-    });
+    await jest.advanceTimersByTimeAsync(2_147_483_647);
 
-    it("cancels a permanently silent stream and reconnects", async () => {
-      const worker = new TaskHubGrpcWorker({
-        logger: new NoOpLogger(),
-        silentDisconnectTimeoutMs: 100,
-      });
-      const { client, mockStream } = createMockClient();
-      const retryMock = jest.fn().mockResolvedValue(undefined);
-      (worker as any)._createNewClientAndRetry = retryMock;
+    expect(jest.getTimerCount()).toBe(0);
+    expect(stream.cancel).not.toHaveBeenCalled();
 
-      await worker.internalRunWorker(client);
-      await jest.advanceTimersByTimeAsync(99);
-
-      expect(mockStream.cancel).not.toHaveBeenCalled();
-      expect(retryMock).not.toHaveBeenCalled();
-
-      await jest.advanceTimersByTimeAsync(1);
-
-      expect(mockStream.cancel).toHaveBeenCalledTimes(1);
-      expect(mockStream.destroy).toHaveBeenCalledTimes(1);
-      expect(retryMock).toHaveBeenCalledTimes(1);
-    });
-
-    it("uses a 120-second silence window by default", async () => {
-      const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-      const { client, mockStream } = createMockClient();
-      const retryMock = jest.fn().mockResolvedValue(undefined);
-      (worker as any)._createNewClientAndRetry = retryMock;
-
-      await worker.internalRunWorker(client);
-      await jest.advanceTimersByTimeAsync(119999);
-
-      expect(mockStream.cancel).not.toHaveBeenCalled();
-
-      await jest.advanceTimersByTimeAsync(1);
-
-      expect(mockStream.cancel).toHaveBeenCalledTimes(1);
-      expect(retryMock).toHaveBeenCalledTimes(1);
-    });
-
-    it("resets the deadline for every message, including health pings", async () => {
-      const worker = new TaskHubGrpcWorker({
-        logger: new NoOpLogger(),
-        silentDisconnectTimeoutMs: 100,
-      });
-      const { client, mockStream } = createMockClient();
-      const retryMock = jest.fn().mockResolvedValue(undefined);
-      (worker as any)._createNewClientAndRetry = retryMock;
-
-      await worker.internalRunWorker(client);
-      await jest.advanceTimersByTimeAsync(60);
-      mockStream.emit("data", new pb.WorkItem());
-      await jest.advanceTimersByTimeAsync(60);
-
-      expect(mockStream.cancel).not.toHaveBeenCalled();
-
-      const healthPing = new pb.WorkItem();
-      healthPing.setHealthping(new pb.HealthPing());
-      mockStream.emit("data", healthPing);
-      await jest.advanceTimersByTimeAsync(99);
-
-      expect(mockStream.cancel).not.toHaveBeenCalled();
-
-      await jest.advanceTimersByTimeAsync(1);
-
-      expect(mockStream.cancel).toHaveBeenCalledTimes(1);
-      expect(retryMock).toHaveBeenCalledTimes(1);
-    });
-
-    it.each(["error", "end"] as const)("cleans up the watchdog after a stream %s", async (event) => {
-      const worker = new TaskHubGrpcWorker({
-        logger: new NoOpLogger(),
-        silentDisconnectTimeoutMs: 100,
-      });
-      const { client, mockStream } = createMockClient();
-      const retryMock = jest.fn().mockResolvedValue(undefined);
-      (worker as any)._createNewClientAndRetry = retryMock;
-
-      await worker.internalRunWorker(client);
-      if (event === "error") {
-        mockStream.emit("error", new Error("14 UNAVAILABLE: Connection lost"));
-      } else {
-        mockStream.emit("end");
-      }
-
-      expect(retryMock).toHaveBeenCalledTimes(1);
-      expect(jest.getTimerCount()).toBe(0);
-
-      await jest.advanceTimersByTimeAsync(100);
-
-      expect(retryMock).toHaveBeenCalledTimes(1);
-      expect(mockStream.cancel).not.toHaveBeenCalled();
-    });
-
-    it("cancels the watchdog during shutdown without reconnecting", async () => {
-      const worker = new TaskHubGrpcWorker({
-        logger: new NoOpLogger(),
-        silentDisconnectTimeoutMs: 10000,
-      });
-      const { client, mockStream } = createMockClient();
-      const retryMock = jest.fn().mockResolvedValue(undefined);
-      (worker as any)._createNewClientAndRetry = retryMock;
-      (worker as any)._isRunning = true;
-      mockStream.cancel.mockImplementation(() => {
-        setTimeout(() => mockStream.emit("close"), 0);
-      });
-
-      await worker.internalRunWorker(client);
-      const stopPromise = worker.stop();
-      await jest.advanceTimersByTimeAsync(1000);
-      await stopPromise;
-
-      expect(jest.getTimerCount()).toBe(0);
-
-      await jest.advanceTimersByTimeAsync(10000);
-
-      expect(retryMock).not.toHaveBeenCalled();
+    controller.abort();
+    await expect(resultPromise).resolves.toEqual({
+      outcome: "shutdown",
+      firstMessageObserved: false,
     });
   });
 
-  it("should retry connection after a stream error event", async () => {
-    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+  it("clamps an oversized timeout to the largest safe Node.js timer delay", () => {
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs: Number.MAX_SAFE_INTEGER,
+    });
 
-    // Prevent actual reconnection — just record that it was attempted
-    const retryMock = jest.fn().mockResolvedValue(undefined);
-    (worker as any)._createNewClientAndRetry = retryMock;
-
-    // Start the worker's internal run (sets up stream event handlers)
-    await worker.internalRunWorker(client);
-
-    // Simulate a transport-level error with no subsequent "end" event
-    mockStream.emit("error", new Error("14 UNAVAILABLE: Connection lost"));
-    await flushAsync();
-
-    // The worker must clean up the stream and attempt to reconnect
-    expect(mockStream.destroy).toHaveBeenCalled();
-    expect(retryMock).toHaveBeenCalledTimes(1);
+    expect((worker as any)._silentDisconnectTimeoutMs).toBe(2_147_483_646);
   });
 
-  it("should not retry when the worker is being stopped", async () => {
-    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+  it("cancels a permanently silent stream", async () => {
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs: 100,
+    });
+    const stream = createMockStream();
+    const resultPromise = consumeStream(worker, stream);
 
-    const retryMock = jest.fn().mockResolvedValue(undefined);
-    (worker as any)._createNewClientAndRetry = retryMock;
+    await jest.advanceTimersByTimeAsync(99);
+    expect(stream.cancel).not.toHaveBeenCalled();
 
-    await worker.internalRunWorker(client);
+    await jest.advanceTimersByTimeAsync(1);
 
-    // Signal that the worker is shutting down
-    (worker as any)._stopWorker = true;
-
-    mockStream.emit("error", new Error("1 CANCELLED"));
-    await flushAsync();
-
-    // During shutdown, errors are silently ignored — no retry
-    expect(retryMock).not.toHaveBeenCalled();
-    expect(mockStream.destroy).not.toHaveBeenCalled();
+    await expect(resultPromise).resolves.toEqual({
+      outcome: "silentDisconnect",
+      firstMessageObserved: false,
+    });
+    expect(stream.cancel).toHaveBeenCalledTimes(1);
+    expect(stream.destroy).toHaveBeenCalledTimes(1);
   });
 
-  it("should remove all stream listeners during error recovery", async () => {
+  it("uses a 120-second silence window by default", async () => {
     const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+    const stream = createMockStream();
+    const resultPromise = consumeStream(worker, stream);
 
-    const retryMock = jest.fn().mockResolvedValue(undefined);
-    (worker as any)._createNewClientAndRetry = retryMock;
+    await jest.advanceTimersByTimeAsync(119999);
+    expect(stream.cancel).not.toHaveBeenCalled();
 
-    await worker.internalRunWorker(client);
+    await jest.advanceTimersByTimeAsync(1);
 
-    // Capture listener counts before error
-    const dataListenersBefore = mockStream.listenerCount("data");
-    expect(dataListenersBefore).toBeGreaterThan(0);
-
-    mockStream.emit("error", new Error("14 UNAVAILABLE: Connection lost"));
-    await flushAsync();
-
-    // After recovery, all original listeners should be removed
-    // (only a no-op error guard remains)
-    expect(mockStream.listenerCount("data")).toBe(0);
-    expect(mockStream.listenerCount("end")).toBe(0);
+    await expect(resultPromise).resolves.toMatchObject({ outcome: "silentDisconnect" });
+    expect(stream.cancel).toHaveBeenCalledTimes(1);
   });
 
-  it("should not crash if a stale error event fires after recovery cleanup", async () => {
-    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+  it("resets the deadline for every message and reports the first health ping", async () => {
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs: 100,
+    });
+    const stream = createMockStream();
+    const onFirstMessage = jest.fn();
+    const resultPromise = consumeStream(worker, stream, undefined, onFirstMessage);
 
-    const retryMock = jest.fn().mockResolvedValue(undefined);
-    (worker as any)._createNewClientAndRetry = retryMock;
+    await jest.advanceTimersByTimeAsync(60);
+    stream.emit("data", new pb.WorkItem());
+    await jest.advanceTimersByTimeAsync(60);
+    expect(stream.cancel).not.toHaveBeenCalled();
 
-    await worker.internalRunWorker(client);
+    const healthPing = new pb.WorkItem();
+    healthPing.setHealthping(new pb.HealthPing());
+    stream.emit("data", healthPing);
+    await jest.advanceTimersByTimeAsync(99);
+    expect(stream.cancel).not.toHaveBeenCalled();
 
-    // First error triggers recovery
-    mockStream.emit("error", new Error("14 UNAVAILABLE: Connection lost"));
-    await flushAsync();
+    await jest.advanceTimersByTimeAsync(1);
 
-    // A stale/duplicate error event must not throw (no-op handler remains)
-    expect(() => {
-      mockStream.emit("error", new Error("Stale error after cleanup"));
-    }).not.toThrow();
+    await expect(resultPromise).resolves.toEqual({
+      outcome: "silentDisconnect",
+      firstMessageObserved: true,
+    });
+    expect(onFirstMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("should recover via the end handler when end fires without error", async () => {
-    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+  it("cleans up the watchdog when the stream errors", async () => {
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs: 100,
+    });
+    const stream = createMockStream();
+    const resultPromise = consumeStream(worker, stream);
+    const error = Object.assign(new Error("unavailable"), {
+      code: grpc.status.UNAVAILABLE,
+      details: "unavailable",
+      metadata: new grpc.Metadata(),
+    });
 
-    const retryMock = jest.fn().mockResolvedValue(undefined);
-    (worker as any)._createNewClientAndRetry = retryMock;
+    stream.emit("error", error);
 
-    await worker.internalRunWorker(client);
+    await expect(resultPromise).rejects.toBe(error);
+    expect(jest.getTimerCount()).toBe(0);
+    expect(stream.destroy).toHaveBeenCalledTimes(1);
 
-    // Simulate a clean stream end (no error)
-    mockStream.emit("end");
-    await flushAsync();
-
-    // The "end" handler should also trigger recovery
-    expect(mockStream.destroy).toHaveBeenCalled();
-    expect(retryMock).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(100);
+    expect(stream.cancel).not.toHaveBeenCalled();
   });
 
-  it("should not crash if _createNewClientAndRetry rejects during error recovery", async () => {
-    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+  it("classifies end as a graceful drain and cleans up the watchdog", async () => {
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs: 100,
+    });
+    const stream = createMockStream();
+    const resultPromise = consumeStream(worker, stream);
 
-    // Simulate a retry that throws — must not become an unhandled rejection
-    const retryMock = jest.fn().mockRejectedValue(new Error("Retry failed"));
-    (worker as any)._createNewClientAndRetry = retryMock;
+    stream.emit("end");
 
-    await worker.internalRunWorker(client);
+    await expect(resultPromise).resolves.toEqual({
+      outcome: "gracefulDrain",
+      firstMessageObserved: false,
+    });
+    expect(jest.getTimerCount()).toBe(0);
+    expect(stream.destroy).toHaveBeenCalledTimes(1);
 
-    // Should not throw or cause unhandled promise rejection
-    mockStream.emit("error", new Error("14 UNAVAILABLE: Connection lost"));
-    await flushAsync();
-
-    expect(retryMock).toHaveBeenCalledTimes(1);
-    expect(mockStream.destroy).toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(100);
+    expect(stream.cancel).not.toHaveBeenCalled();
   });
 
-  it("should not crash if _createNewClientAndRetry rejects during end recovery", async () => {
-    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+  it("classifies worker cancellation as shutdown without leaving a watchdog", async () => {
+    const worker = new TaskHubGrpcWorker({
+      logger: new NoOpLogger(),
+      silentDisconnectTimeoutMs: 100,
+    });
+    const stream = createMockStream();
+    const controller = new AbortController();
+    const resultPromise = consumeStream(worker, stream, controller.signal);
 
-    // Simulate a retry that throws — must not become an unhandled rejection
-    const retryMock = jest.fn().mockRejectedValue(new Error("Retry failed"));
-    (worker as any)._createNewClientAndRetry = retryMock;
+    controller.abort();
 
-    await worker.internalRunWorker(client);
-
-    // Should not throw or cause unhandled promise rejection
-    mockStream.emit("end");
-    await flushAsync();
-
-    expect(retryMock).toHaveBeenCalledTimes(1);
-    expect(mockStream.destroy).toHaveBeenCalled();
+    await expect(resultPromise).resolves.toEqual({
+      outcome: "shutdown",
+      firstMessageObserved: false,
+    });
+    expect(jest.getTimerCount()).toBe(0);
+    expect(stream.cancel).not.toHaveBeenCalled();
+    expect(stream.destroy).not.toHaveBeenCalled();
   });
 
-  it("should also add no-op error guard in end handler to prevent crashes after cleanup", async () => {
+  it("guards against stale errors after terminal cleanup", async () => {
     const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
-    const { client, mockStream } = createMockClient();
+    const stream = createMockStream();
+    const resultPromise = consumeStream(worker, stream);
 
-    const retryMock = jest.fn().mockResolvedValue(undefined);
-    (worker as any)._createNewClientAndRetry = retryMock;
+    stream.emit("end");
+    await resultPromise;
 
-    await worker.internalRunWorker(client);
-
-    // End fires → cleanup removes all listeners
-    mockStream.emit("end");
-    await flushAsync();
-
-    // A stale error after end cleanup must not crash
-    expect(() => {
-      mockStream.emit("error", new Error("Stale error after end cleanup"));
-    }).not.toThrow();
-
-    // The no-op guard should remain
-    expect(mockStream.listenerCount("error")).toBe(1);
+    expect(() => stream.emit("error", new Error("stale error"))).not.toThrow();
+    expect(stream.listenerCount("error")).toBe(1);
   });
 });

--- a/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
+++ b/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
@@ -31,10 +31,9 @@ const taskHub = process.env.TASKHUB || "default";
 const EMULATOR_CONTAINER = "dts-emulator-stream-recovery-test";
 const EMULATOR_IMAGE = "mcr.microsoft.com/dts/dts-emulator:latest";
 const EMULATOR_PORT = endpoint.split(":")[1] || "8080";
-const WATCHDOG_TIMEOUT_MS = 3000;
-const WATCHDOG_EVENT_TIMEOUT_MS = 15000;
-const DISABLED_WATCHDOG_PAUSE_MS = 6000;
-const WORKER_CONNECTION_TIMEOUT_MS = 30000;
+const WATCHDOG_TIMEOUT_MS = 10000;
+const WATCHDOG_EVENT_TIMEOUT_MS = 30000;
+const DISABLED_WATCHDOG_PAUSE_MS = WATCHDOG_TIMEOUT_MS + 5000;
 
 /** Structured logger that captures log events for assertion. */
 class CapturingLogger implements StructuredLogger {
@@ -79,7 +78,7 @@ function stopEmulator(): void {
   try {
     unpauseEmulator();
   } catch {
-    // Container didn't exist or wasn't paused — fine
+    // Container may not exist or may already be running.
   }
   try {
     execSync(`docker rm -f ${EMULATOR_CONTAINER}`, { stdio: "ignore" });
@@ -103,11 +102,11 @@ function unpauseEmulator(): void {
 }
 
 function isEmulatorPaused(): boolean {
-  return execSync(`docker inspect --format={{.State.Paused}} ${EMULATOR_CONTAINER}`)
-    .toString()
-    .trim()
-    .toLowerCase()
-    .startsWith("true");
+  return (
+    execSync(`docker inspect --format "{{.State.Paused}}" ${EMULATOR_CONTAINER}`, {
+      encoding: "utf8",
+    }).trim() === "true"
+  );
 }
 
 /** Poll until a condition is true or timeout. */
@@ -128,6 +127,7 @@ const EVENT_STREAM_ERROR = 704;
 const EVENT_CONNECTION_RETRY = 709;
 const EVENT_STREAM_ERROR_INFO = 736;
 const EVENT_STREAM_TIMEOUT = 738;
+const EVENT_CHANNEL_RECREATING = 739;
 const EVENT_CHANNEL_RECREATED = 740;
 
 describe("Worker Stream Recovery E2E", () => {
@@ -255,184 +255,167 @@ describe("Worker Stream Recovery E2E", () => {
     }
   }, 90000);
 
-  it("recovers a paused established stream through the watchdog and channel recreation", async () => {
+  it("should reconnect a paused established stream and complete new work", async () => {
     if (skipReason) {
-      console.log(`Skipping paused stream watchdog e2e test: ${skipReason}`);
+      console.log(`Skipping stream recovery e2e test: ${skipReason}`);
       return;
     }
 
+    startEmulator();
     const logger = new CapturingLogger();
-    const orchestrator: TOrchestrator = async function pausedStreamWatchdogOrchestrator(_: OrchestrationContext) {
-      return "paused-stream-watchdog-recovery";
-    };
     const worker = new DurableTaskAzureManagedWorkerBuilder()
       .endpoint(endpoint, taskHub, null)
       .logger(logger)
       .silentDisconnectTimeout(WATCHDOG_TIMEOUT_MS)
       .channelRecreateFailureThreshold(1)
       .build();
+    const client = new DurableTaskAzureManagedClientBuilder().endpoint(endpoint, taskHub, null).build();
+    const orchestrator: TOrchestrator = async function pausedStreamOrchestrator(_: OrchestrationContext) {
+      return "paused-stream-recovery-success";
+    };
     worker.addOrchestrator(orchestrator);
 
     let workerRunning = false;
     let emulatorPaused = false;
-    let client: ReturnType<DurableTaskAzureManagedClientBuilder["build"]> | undefined;
-
+    let instanceId: string | undefined;
     try {
-      startEmulator();
       await worker.start();
       workerRunning = true;
-
-      const initiallyConnected = await waitFor(
-        () => logger.getByEventId(EVENT_WORKER_CONNECTED).length > 0,
-        WORKER_CONNECTION_TIMEOUT_MS,
-      );
-      expect(initiallyConnected).toBe(true);
+      expect(await waitFor(() => logger.getByEventId(EVENT_WORKER_CONNECTED).length === 1, 30000, 100)).toBe(true);
 
       logger.clear();
       pauseEmulator();
       emulatorPaused = true;
 
-      const watchdogRecreatedChannel = await waitFor(
-        () =>
-          logger.getByEventId(EVENT_STREAM_TIMEOUT).length > 0 &&
-          logger.getByEventId(EVENT_CHANNEL_RECREATED).length > 0,
-        WATCHDOG_EVENT_TIMEOUT_MS,
-        100,
-      );
-      expect(watchdogRecreatedChannel).toBe(true);
+      expect(
+        await waitFor(() => logger.getByEventId(EVENT_STREAM_TIMEOUT).length === 1, WATCHDOG_EVENT_TIMEOUT_MS, 100),
+      ).toBe(true);
+      expect(logger.getByEventId(EVENT_CHANNEL_RECREATING)).toHaveLength(1);
+      expect(logger.getByEventId(EVENT_CHANNEL_RECREATED)).toHaveLength(1);
       expect(isEmulatorPaused()).toBe(true);
 
       const timeoutIndex = logger.events.findIndex((event) => event.eventId === EVENT_STREAM_TIMEOUT);
-      const recreationIndex = logger.events.findIndex((event) => event.eventId === EVENT_CHANNEL_RECREATED);
-      const precedingEventIds = logger.events.slice(0, timeoutIndex).map((event) => event.eventId);
-
+      const recreatingIndex = logger.events.findIndex((event) => event.eventId === EVENT_CHANNEL_RECREATING);
+      const recreatedIndex = logger.events.findIndex((event) => event.eventId === EVENT_CHANNEL_RECREATED);
       expect(timeoutIndex).toBeGreaterThanOrEqual(0);
-      expect(recreationIndex).toBeGreaterThan(timeoutIndex);
-      expect(precedingEventIds).not.toContain(EVENT_STREAM_ENDED);
-      expect(precedingEventIds).not.toContain(EVENT_STREAM_ERROR);
-      expect(precedingEventIds).not.toContain(EVENT_STREAM_ERROR_INFO);
-      expect(logger.getByEventId(EVENT_WORKER_CONNECTED)).toHaveLength(0);
+      expect(recreatingIndex).toBeGreaterThan(timeoutIndex);
+      expect(recreatedIndex).toBeGreaterThan(recreatingIndex);
+      expect(
+        logger.events
+          .slice(0, timeoutIndex)
+          .filter(
+            (event) =>
+              event.eventId === EVENT_STREAM_ENDED ||
+              event.eventId === EVENT_STREAM_ERROR ||
+              event.eventId === EVENT_STREAM_ERROR_INFO,
+          ),
+      ).toHaveLength(0);
 
       unpauseEmulator();
       emulatorPaused = false;
+      expect(await waitFor(() => logger.getByEventId(EVENT_WORKER_CONNECTED).length === 1, 30000, 100)).toBe(true);
 
-      const replacementConnected = await waitFor(
-        () => logger.getByEventId(EVENT_WORKER_CONNECTED).length > 0,
-        WORKER_CONNECTION_TIMEOUT_MS,
-      );
-      expect(replacementConnected).toBe(true);
+      instanceId = await client.scheduleNewOrchestration(orchestrator);
+      const state = await client.waitForOrchestrationCompletion(instanceId, undefined, 30);
 
-      client = new DurableTaskAzureManagedClientBuilder().endpoint(endpoint, taskHub, null).build();
-      const id = await client.scheduleNewOrchestration(orchestrator);
-      const state = await client.waitForOrchestrationCompletion(id, undefined, 30);
-
-      expect(state).toBeDefined();
-      expect(state?.runtimeStatus).toBe(OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
-      expect(state?.serializedOutput).toBe(JSON.stringify("paused-stream-watchdog-recovery"));
+      expect(state?.runtimeStatus).toEqual(OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+      expect(state?.serializedOutput).toEqual(JSON.stringify("paused-stream-recovery-success"));
+      expect((await client.purgeOrchestration(instanceId))?.deletedInstanceCount).toBe(1);
+      instanceId = undefined;
     } finally {
       if (emulatorPaused) {
         try {
           unpauseEmulator();
         } catch {
-          // Cleanup continues with forced container removal
+          // Best-effort so worker and container cleanup can continue.
         }
       }
-      try {
-        if (workerRunning) {
-          await worker.stop();
-        }
-      } finally {
+      if (instanceId) {
         try {
-          await client?.stop();
-        } finally {
-          stopEmulator();
+          await client.terminateOrchestration(instanceId, "test cleanup");
+        } catch {
+          // The instance may already be terminal.
         }
       }
+      if (workerRunning) {
+        await worker.stop();
+      }
+      await client.stop();
+      stopEmulator();
     }
-  }, 90000);
+  }, 120000);
 
-  it("leaves a paused established stream connected when the watchdog is disabled", async () => {
+  it("should leave a paused stream alone when the watchdog is disabled", async () => {
     if (skipReason) {
-      console.log(`Skipping disabled paused stream watchdog e2e test: ${skipReason}`);
+      console.log(`Skipping stream recovery e2e test: ${skipReason}`);
       return;
     }
 
-    expect(DISABLED_WATCHDOG_PAUSE_MS).toBeGreaterThan(WATCHDOG_TIMEOUT_MS);
-
+    startEmulator();
     const logger = new CapturingLogger();
-    const orchestrator: TOrchestrator = async function pausedStreamWithoutWatchdogOrchestrator(
-      _: OrchestrationContext,
-    ) {
-      return "paused-stream-without-watchdog";
-    };
     const worker = new DurableTaskAzureManagedWorkerBuilder()
       .endpoint(endpoint, taskHub, null)
       .logger(logger)
       .silentDisconnectTimeout(0)
       .channelRecreateFailureThreshold(1)
       .build();
+    const client = new DurableTaskAzureManagedClientBuilder().endpoint(endpoint, taskHub, null).build();
+    const orchestrator: TOrchestrator = async function disabledWatchdogOrchestrator(_: OrchestrationContext) {
+      return "disabled-watchdog-success";
+    };
     worker.addOrchestrator(orchestrator);
 
     let workerRunning = false;
     let emulatorPaused = false;
-    let client: ReturnType<DurableTaskAzureManagedClientBuilder["build"]> | undefined;
-
+    let instanceId: string | undefined;
     try {
-      startEmulator();
       await worker.start();
       workerRunning = true;
-
-      const initiallyConnected = await waitFor(
-        () => logger.getByEventId(EVENT_WORKER_CONNECTED).length > 0,
-        WORKER_CONNECTION_TIMEOUT_MS,
-      );
-      expect(initiallyConnected).toBe(true);
+      expect(await waitFor(() => logger.getByEventId(EVENT_WORKER_CONNECTED).length === 1, 30000, 100)).toBe(true);
 
       logger.clear();
       pauseEmulator();
       emulatorPaused = true;
-
       await new Promise((resolve) => setTimeout(resolve, DISABLED_WATCHDOG_PAUSE_MS));
 
       expect(isEmulatorPaused()).toBe(true);
       expect(logger.getByEventId(EVENT_STREAM_TIMEOUT)).toHaveLength(0);
       expect(logger.getByEventId(EVENT_STREAM_RETRY)).toHaveLength(0);
       expect(logger.getByEventId(EVENT_CONNECTION_RETRY)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_CHANNEL_RECREATING)).toHaveLength(0);
       expect(logger.getByEventId(EVENT_CHANNEL_RECREATED)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_WORKER_CONNECTED)).toHaveLength(0);
 
       unpauseEmulator();
       emulatorPaused = false;
+      instanceId = await client.scheduleNewOrchestration(orchestrator);
+      const state = await client.waitForOrchestrationCompletion(instanceId, undefined, 30);
 
-      client = new DurableTaskAzureManagedClientBuilder().endpoint(endpoint, taskHub, null).build();
-      const id = await client.scheduleNewOrchestration(orchestrator);
-      const state = await client.waitForOrchestrationCompletion(id, undefined, 30);
-
-      expect(state).toBeDefined();
-      expect(state?.runtimeStatus).toBe(OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
-      expect(state?.serializedOutput).toBe(JSON.stringify("paused-stream-without-watchdog"));
+      expect(state?.runtimeStatus).toEqual(OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+      expect(state?.serializedOutput).toEqual(JSON.stringify("disabled-watchdog-success"));
       expect(logger.getByEventId(EVENT_WORKER_CONNECTED)).toHaveLength(0);
-      expect(logger.getByEventId(EVENT_STREAM_RETRY)).toHaveLength(0);
-      expect(logger.getByEventId(EVENT_CONNECTION_RETRY)).toHaveLength(0);
-      expect(logger.getByEventId(EVENT_CHANNEL_RECREATED)).toHaveLength(0);
+      expect((await client.purgeOrchestration(instanceId))?.deletedInstanceCount).toBe(1);
+      instanceId = undefined;
     } finally {
       if (emulatorPaused) {
         try {
           unpauseEmulator();
         } catch {
-          // Cleanup continues with forced container removal
+          // Best-effort so worker and container cleanup can continue.
         }
       }
-      try {
-        if (workerRunning) {
-          await worker.stop();
-        }
-      } finally {
+      if (instanceId) {
         try {
-          await client?.stop();
-        } finally {
-          stopEmulator();
+          await client.terminateOrchestration(instanceId, "test cleanup");
+        } catch {
+          // The instance may already be terminal.
         }
       }
+      if (workerRunning) {
+        await worker.stop();
+      }
+      await client.stop();
+      stopEmulator();
     }
-  }, 90000);
+  }, 120000);
 });

--- a/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
+++ b/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
@@ -31,6 +31,10 @@ const taskHub = process.env.TASKHUB || "default";
 const EMULATOR_CONTAINER = "dts-emulator-stream-recovery-test";
 const EMULATOR_IMAGE = "mcr.microsoft.com/dts/dts-emulator:latest";
 const EMULATOR_PORT = endpoint.split(":")[1] || "8080";
+const WATCHDOG_TIMEOUT_MS = 3000;
+const WATCHDOG_EVENT_TIMEOUT_MS = 15000;
+const DISABLED_WATCHDOG_PAUSE_MS = 6000;
+const WORKER_CONNECTION_TIMEOUT_MS = 30000;
 
 /** Structured logger that captures log events for assertion. */
 class CapturingLogger implements StructuredLogger {
@@ -73,6 +77,11 @@ function isDockerAvailable(): boolean {
 
 function stopEmulator(): void {
   try {
+    unpauseEmulator();
+  } catch {
+    // Container didn't exist or wasn't paused — fine
+  }
+  try {
     execSync(`docker rm -f ${EMULATOR_CONTAINER}`, { stdio: "ignore" });
   } catch {
     // Container didn't exist — fine
@@ -83,6 +92,22 @@ function startEmulator(): void {
   execSync(`docker run --name ${EMULATOR_CONTAINER} -d --rm -p ${EMULATOR_PORT}:8080 ${EMULATOR_IMAGE}`, {
     stdio: "ignore",
   });
+}
+
+function pauseEmulator(): void {
+  execSync(`docker pause ${EMULATOR_CONTAINER}`, { stdio: "ignore" });
+}
+
+function unpauseEmulator(): void {
+  execSync(`docker unpause ${EMULATOR_CONTAINER}`, { stdio: "ignore" });
+}
+
+function isEmulatorPaused(): boolean {
+  return execSync(`docker inspect --format={{.State.Paused}} ${EMULATOR_CONTAINER}`)
+    .toString()
+    .trim()
+    .toLowerCase()
+    .startsWith("true");
 }
 
 /** Poll until a condition is true or timeout. */
@@ -97,8 +122,13 @@ async function waitFor(predicate: () => boolean, timeoutMs: number, intervalMs =
 
 // Log event IDs from packages/durabletask-js/src/worker/logs.ts
 const EVENT_WORKER_CONNECTED = 700;
+const EVENT_STREAM_ENDED = 702;
 const EVENT_STREAM_RETRY = 703;
+const EVENT_STREAM_ERROR = 704;
 const EVENT_CONNECTION_RETRY = 709;
+const EVENT_STREAM_ERROR_INFO = 736;
+const EVENT_STREAM_TIMEOUT = 738;
+const EVENT_CHANNEL_RECREATED = 740;
 
 describe("Worker Stream Recovery E2E", () => {
   const skipReason = !isDockerAvailable() ? "Docker not available" : null;
@@ -222,6 +252,187 @@ describe("Worker Stream Recovery E2E", () => {
         await worker.stop();
       }
       await client?.stop();
+    }
+  }, 90000);
+
+  it("recovers a paused established stream through the watchdog and channel recreation", async () => {
+    if (skipReason) {
+      console.log(`Skipping paused stream watchdog e2e test: ${skipReason}`);
+      return;
+    }
+
+    const logger = new CapturingLogger();
+    const orchestrator: TOrchestrator = async function pausedStreamWatchdogOrchestrator(_: OrchestrationContext) {
+      return "paused-stream-watchdog-recovery";
+    };
+    const worker = new DurableTaskAzureManagedWorkerBuilder()
+      .endpoint(endpoint, taskHub, null)
+      .logger(logger)
+      .silentDisconnectTimeout(WATCHDOG_TIMEOUT_MS)
+      .channelRecreateFailureThreshold(1)
+      .build();
+    worker.addOrchestrator(orchestrator);
+
+    let workerRunning = false;
+    let emulatorPaused = false;
+    let client: ReturnType<DurableTaskAzureManagedClientBuilder["build"]> | undefined;
+
+    try {
+      startEmulator();
+      await worker.start();
+      workerRunning = true;
+
+      const initiallyConnected = await waitFor(
+        () => logger.getByEventId(EVENT_WORKER_CONNECTED).length > 0,
+        WORKER_CONNECTION_TIMEOUT_MS,
+      );
+      expect(initiallyConnected).toBe(true);
+
+      logger.clear();
+      pauseEmulator();
+      emulatorPaused = true;
+
+      const watchdogRecreatedChannel = await waitFor(
+        () =>
+          logger.getByEventId(EVENT_STREAM_TIMEOUT).length > 0 &&
+          logger.getByEventId(EVENT_CHANNEL_RECREATED).length > 0,
+        WATCHDOG_EVENT_TIMEOUT_MS,
+        100,
+      );
+      expect(watchdogRecreatedChannel).toBe(true);
+      expect(isEmulatorPaused()).toBe(true);
+
+      const timeoutIndex = logger.events.findIndex((event) => event.eventId === EVENT_STREAM_TIMEOUT);
+      const recreationIndex = logger.events.findIndex((event) => event.eventId === EVENT_CHANNEL_RECREATED);
+      const precedingEventIds = logger.events.slice(0, timeoutIndex).map((event) => event.eventId);
+
+      expect(timeoutIndex).toBeGreaterThanOrEqual(0);
+      expect(recreationIndex).toBeGreaterThan(timeoutIndex);
+      expect(precedingEventIds).not.toContain(EVENT_STREAM_ENDED);
+      expect(precedingEventIds).not.toContain(EVENT_STREAM_ERROR);
+      expect(precedingEventIds).not.toContain(EVENT_STREAM_ERROR_INFO);
+      expect(logger.getByEventId(EVENT_WORKER_CONNECTED)).toHaveLength(0);
+
+      unpauseEmulator();
+      emulatorPaused = false;
+
+      const replacementConnected = await waitFor(
+        () => logger.getByEventId(EVENT_WORKER_CONNECTED).length > 0,
+        WORKER_CONNECTION_TIMEOUT_MS,
+      );
+      expect(replacementConnected).toBe(true);
+
+      client = new DurableTaskAzureManagedClientBuilder().endpoint(endpoint, taskHub, null).build();
+      const id = await client.scheduleNewOrchestration(orchestrator);
+      const state = await client.waitForOrchestrationCompletion(id, undefined, 30);
+
+      expect(state).toBeDefined();
+      expect(state?.runtimeStatus).toBe(OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+      expect(state?.serializedOutput).toBe(JSON.stringify("paused-stream-watchdog-recovery"));
+    } finally {
+      if (emulatorPaused) {
+        try {
+          unpauseEmulator();
+        } catch {
+          // Cleanup continues with forced container removal
+        }
+      }
+      try {
+        if (workerRunning) {
+          await worker.stop();
+        }
+      } finally {
+        try {
+          await client?.stop();
+        } finally {
+          stopEmulator();
+        }
+      }
+    }
+  }, 90000);
+
+  it("leaves a paused established stream connected when the watchdog is disabled", async () => {
+    if (skipReason) {
+      console.log(`Skipping disabled paused stream watchdog e2e test: ${skipReason}`);
+      return;
+    }
+
+    expect(DISABLED_WATCHDOG_PAUSE_MS).toBeGreaterThan(WATCHDOG_TIMEOUT_MS);
+
+    const logger = new CapturingLogger();
+    const orchestrator: TOrchestrator = async function pausedStreamWithoutWatchdogOrchestrator(
+      _: OrchestrationContext,
+    ) {
+      return "paused-stream-without-watchdog";
+    };
+    const worker = new DurableTaskAzureManagedWorkerBuilder()
+      .endpoint(endpoint, taskHub, null)
+      .logger(logger)
+      .silentDisconnectTimeout(0)
+      .channelRecreateFailureThreshold(1)
+      .build();
+    worker.addOrchestrator(orchestrator);
+
+    let workerRunning = false;
+    let emulatorPaused = false;
+    let client: ReturnType<DurableTaskAzureManagedClientBuilder["build"]> | undefined;
+
+    try {
+      startEmulator();
+      await worker.start();
+      workerRunning = true;
+
+      const initiallyConnected = await waitFor(
+        () => logger.getByEventId(EVENT_WORKER_CONNECTED).length > 0,
+        WORKER_CONNECTION_TIMEOUT_MS,
+      );
+      expect(initiallyConnected).toBe(true);
+
+      logger.clear();
+      pauseEmulator();
+      emulatorPaused = true;
+
+      await new Promise((resolve) => setTimeout(resolve, DISABLED_WATCHDOG_PAUSE_MS));
+
+      expect(isEmulatorPaused()).toBe(true);
+      expect(logger.getByEventId(EVENT_STREAM_TIMEOUT)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_STREAM_RETRY)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_CONNECTION_RETRY)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_CHANNEL_RECREATED)).toHaveLength(0);
+
+      unpauseEmulator();
+      emulatorPaused = false;
+
+      client = new DurableTaskAzureManagedClientBuilder().endpoint(endpoint, taskHub, null).build();
+      const id = await client.scheduleNewOrchestration(orchestrator);
+      const state = await client.waitForOrchestrationCompletion(id, undefined, 30);
+
+      expect(state).toBeDefined();
+      expect(state?.runtimeStatus).toBe(OrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+      expect(state?.serializedOutput).toBe(JSON.stringify("paused-stream-without-watchdog"));
+      expect(logger.getByEventId(EVENT_WORKER_CONNECTED)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_STREAM_RETRY)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_CONNECTION_RETRY)).toHaveLength(0);
+      expect(logger.getByEventId(EVENT_CHANNEL_RECREATED)).toHaveLength(0);
+    } finally {
+      if (emulatorPaused) {
+        try {
+          unpauseEmulator();
+        } catch {
+          // Cleanup continues with forced container removal
+        }
+      }
+      try {
+        if (workerRunning) {
+          await worker.stop();
+        }
+      } finally {
+        try {
+          await client?.stop();
+        } finally {
+          stopEmulator();
+        }
+      }
     }
   }, 90000);
 });


### PR DESCRIPTION
# Summary

## What changed?
- Added a resettable work-item stream inactivity watchdog with a 120-second default.
- Replaced recursive reconnect callbacks with one sequential recovery loop.
- Aligned established-stream recovery with durabletask-dotnet commit [`86a4def`](https://github.com/microsoft/durabletask-dotnet/commit/86a4defc4746072bf62a0aeae36375ba5d77dead).
- Added public `silentDisconnectTimeoutMs` and `channelRecreateFailureThreshold` core options plus Azure-managed builder methods.
- Added deterministic unit and Docker emulator coverage for stream outcomes, paused connections, counter resets, isolated channel recreation, status classification, backoff, deferred disposal, and teardown races.

## Why is this change needed?
A half-open HTTP/2/gRPC stream can remain open without delivering messages or terminal events, leaving the worker idle indefinitely. Recovery also needs to avoid recreating healthy channels on every stream transition, reusing a poisoned pooled transport, or reconnecting workers in lockstep during an outage.

## .NET parity scope

| Established-stream behavior | JavaScript behavior |
|---|---|
| Silent timeout defaults to 120 seconds | `silentDisconnectTimeoutMs` defaults to `120000` |
| Non-positive timeout disables detection | `<= 0` arms no watchdog |
| Very large timeout is clamped | Finite values clamp to Node's safe timer ceiling (`2_147_483_646` ms) |
| First message, including health ping, resets recovery state | Backoff and poison counters reset before first-message dispatch; Hello alone does not reset them |
| Shutdown, silence, and graceful drain are distinct | Idempotent stream consumer returns distinct outcomes and emits distinct timeout/drain logs |
| Empty graceful drain and silence poison the channel; non-empty drain does not | Same classification using `firstMessageObserved` |
| Full-jitter exponential reconnect delay | Uniform delay in `[0, min(30s, 1s * 2^attempt)]`, with the exact selected delay logged and shutdown-cancellable |
| Reuse channel until five poisoned failures | Same `GrpcClient` is reused until the default threshold of 5; non-positive threshold disables recreation |
| Channel recreation uses a fresh transport | Every replacement passes `"grpc.use_local_subchannel_pool": 1`; grpc-js 1.14.4 then uses a per-channel `SubchannelPool` instead of its global pool |
| `UNAVAILABLE`/Hello `DEADLINE_EXCEEDED` poison | Same grpc-js status classification |
| `CANCELLED`/`NOT_FOUND` do not poison; `UNAUTHENTICATED` resets recovery state | Same grpc-js status classification and reset behavior |
| Replaced channel disposal is deferred 30 seconds | Old stubs remain usable for in-flight completion RPCs for 30 seconds, and shutdown closes all deferred stubs after pending work drains |
| Failed channel recreation falls back to current transport | Construction failure is logged and the loop continues on the existing client |

Node maps .NET cancellation-token stream consumption to grpc-js `data`/`end`/`error` events plus `ClientReadableStream.cancel()`. The event implementation uses a single terminal latch and removes listeners before watchdog cancellation so cancel-induced errors cannot schedule a second reconnect. No unrelated completion-RPC retry, history streaming, payload, or concurrency parity work is included.

**Health-ping compatibility:** Keep the 120-second default for .NET/Durable Task Scheduler parity. Backends that do not emit work-item `HealthPing`s must configure `silentDisconnectTimeoutMs: 0` (or Azure builder `.silentDisconnectTimeout(0)`), otherwise a healthy idle stream will time out every two minutes and recreate its transport every fifth timeout. This includes durabletask-go main at [`d822bceb`](https://github.com/microsoft/durabletask-go/tree/d822bceb12134e19fc077623dfa3a3b5245cce11): its [`GetWorkItems`](https://github.com/microsoft/durabletask-go/blob/d822bceb12134e19fc077623dfa3a3b5245cce11/backend/executor.go) loop sends only queued work items and has no health-ping branch.

## Issues / work items
- Resolves N/A
- Related N/A

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to core and Azure-managed `CHANGELOG.md` files
- [x] Backport is not required
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [x] Breaking change? No

---

# AI-assisted code disclosure (required)

## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot
- AI-assisted areas/files: Worker recovery loop, watchdog, backoff extension, structured lifecycle logs, unit/E2E tests, Azure-managed builder wiring, and changelogs
- What you changed after AI output: Expanded the original watchdog-only change to the exact established-stream recovery contract from `86a4def`; added deferred channel disposal, isolated grpc-js replacement transports, real paused-connection E2E coverage, and distinct outcome/recreation observability after independent review

AI verification (required if AI was used):
- [x] I understand the code and can explain it
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing

## TDD evidence
Each production behavior was introduced with an observed RED before implementation. Representative failures included non-positive timeout rejection, missing timeout clamp, Hello resetting retry state, symmetric rather than full jitter, per-retry channel recreation, missing threshold escalation/reset/status classification, immediate old-channel disposal, missed synchronous shutdown close, missing lifecycle events, and recreated clients still using grpc-js's global subchannel pool. Every regression test was rerun GREEN after its minimal implementation.

## Automated paused-stream watchdog E2E
- Gated in the existing Node 22/24 `worker-recovery` matrix; no credentials or mocks.
- Local environment: Docker Desktop 29.2.1 (Linux containers), Node.js v24.14.0.
- Exact CI command passed three times: `npx jest test/e2e-azuremanaged/worker-stream-recovery.spec.ts --runInBand --detectOpenHandles` in **80.993s**, **71.882s**, and **70.587s** (4/4 tests each).
- `should reconnect a paused established stream and complete new work` passed in **17.832s**, **17.614s**, and **17.203s**. With a 10s watchdog and threshold 1, Docker paused the already-connected emulator; event 738 occurred before 739/740 while the container remained paused and with no preceding 702/704/736. After unpause, the isolated replacement connected, completed real work with exact output, and the instance was purged.
- `should leave a paused stream alone when the watchdog is disabled` passed in **23.191s**, **23.444s**, and **22.449s**. During an intentional 15s pause (longer than the enabled watchdog), events 738/703/709/739/740 remained absent. After unpause, the original stream completed real work with exact output, no second 700 connection event appeared, and the instance was purged.
- Flake mitigation: named 10s/15s/30s timing constants, 100ms event polling, event-order assertions instead of implementation internals, and best-effort unpause before worker/client/container teardown. The full file stays around 71 seconds, well below the 15-minute CI limit.

## Automated tests and checks
- Focused worker recovery/startup unit suites: **38/38 passed**
- Azure-managed builder unit suite: **8/8 passed**
- Core full unit suite: **1,274/1,274 passed**
- Azure-managed full unit suite: **111/111 passed**
- `npm run build:core`: passed
- `npm run build:azuremanaged`: passed
- Full repository ESLint: passed
- Changed-file Prettier and `git diff --check`: passed

## Real Azure validation
- Existing redacted Azure `Microsoft.DurableTask/schedulers/taskHubs` resource in East Asia via Azure CLI; no identifiers or credentials persisted.
- Latest production-head watchdog/isolation proof used a 10s watchdog and threshold 1: real stream cancellation, distinct timeout, one isolated channel recreation, replacement connection, then an activity-backed orchestration completed with verified output and was purged 1/1.
- A separate timeout-0 run received a real health ping with zero timeout/retry events and exactly one connection.
- This is a controlled silence-window proxy on the real Azure transport, not a packet-level half-open. The committed Docker E2E now supplies deterministic paused-transport coverage without credentials.

---

# Notes for reviewers
- Reference files: [`WorkItemStreamConsumer.cs`](https://github.com/microsoft/durabletask-dotnet/blob/86a4defc4746072bf62a0aeae36375ba5d77dead/src/Worker/Grpc/WorkItemStreamConsumer.cs), [`GrpcDurableTaskWorker.Processor.cs`](https://github.com/microsoft/durabletask-dotnet/blob/86a4defc4746072bf62a0aeae36375ba5d77dead/src/Worker/Grpc/GrpcDurableTaskWorker.Processor.cs), and [`GrpcDurableTaskWorkerOptions.cs`](https://github.com/microsoft/durabletask-dotnet/blob/86a4defc4746072bf62a0aeae36375ba5d77dead/src/Worker/Grpc/GrpcDurableTaskWorkerOptions.cs).
- grpc-js 1.14.4 source: [`internal-channel.ts`](https://github.com/grpc/grpc-node/blob/%40grpc/grpc-js%401.14.4/packages/grpc-js/src/internal-channel.ts) selects the global pool unless `grpc.use_local_subchannel_pool` is nonzero.
- The repository-wide Prettier command reports pre-existing differences in untouched files; all changed files that were already formatter-clean remain clean, and the intentionally pre-existing formatting in `worker/logs.ts` was preserved.