### PR TITLE
fix(azuremanaged): select TLS from endpoint scheme

### DIFF
--- a/.github/workflows/dts-e2e-tests.yaml
+++ b/.github/workflows/dts-e2e-tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: 🔧 Set environment variables
         run: |
           echo "TASKHUB=default" >> $GITHUB_ENV
-          echo "ENDPOINT=localhost:8080" >> $GITHUB_ENV
+          echo "ENDPOINT=http://localhost:8080" >> $GITHUB_ENV
 
       - name: ⚙️ NodeJS - Install
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -26,7 +26,7 @@ npm run start:emulator
 ### Expected Output
 
 ```
-Connecting to endpoint: localhost:8080, taskHub: default
+Connecting to endpoint: http://localhost:8080, taskHub: default
 Worker started successfully
 
 --- Signaling entity operations ---
@@ -56,7 +56,7 @@ npm run start:emulator
 ### Expected Output
 
 ```
-Connecting to endpoint: localhost:8080, taskHub: default
+Connecting to endpoint: http://localhost:8080, taskHub: default
 Worker started successfully
 
 --- Initializing accounts ---

--- a/examples/entity-counter/README.md
+++ b/examples/entity-counter/README.md
@@ -45,7 +45,7 @@ npm run start
 ## Expected Output
 
 ```
-Connecting to endpoint: localhost:8080, taskHub: default
+Connecting to endpoint: http://localhost:8080, taskHub: default
 Worker started successfully
 
 --- Signaling entity operations ---

--- a/examples/entity-counter/index.ts
+++ b/examples/entity-counter/index.ts
@@ -26,7 +26,7 @@ import {
 } from "@microsoft/durabletask-js-azuremanaged";
 
 // Read environment variables for DTS emulator or local sidecar
-const endpoint = process.env.ENDPOINT || "localhost:4001";
+const endpoint = process.env.ENDPOINT || "http://localhost:4001";
 const taskHub = process.env.TASKHUB || "default";
 
 // ============================================================================

--- a/examples/entity-counter/package.json
+++ b/examples/entity-counter/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "ts-node --swc index.ts",
-    "start:emulator": "ENDPOINT=localhost:8080 TASKHUB=default ts-node --swc index.ts"
+    "start:emulator": "ENDPOINT=http://localhost:8080 TASKHUB=default ts-node --swc index.ts"
   },
   "dependencies": {
     "@microsoft/durabletask-js": "workspace:*",

--- a/examples/entity-orchestration/README.md
+++ b/examples/entity-orchestration/README.md
@@ -44,7 +44,7 @@ npm run start
 ## Expected Output
 
 ```
-Connecting to endpoint: localhost:8080, taskHub: default
+Connecting to endpoint: http://localhost:8080, taskHub: default
 Worker started successfully
 
 --- Initializing accounts ---

--- a/examples/entity-orchestration/index.ts
+++ b/examples/entity-orchestration/index.ts
@@ -31,7 +31,7 @@ import {
 } from "@microsoft/durabletask-js-azuremanaged";
 
 // Read environment variables for DTS emulator or local sidecar
-const endpoint = process.env.ENDPOINT || "localhost:4001";
+const endpoint = process.env.ENDPOINT || "http://localhost:4001";
 const taskHub = process.env.TASKHUB || "default";
 
 // ============================================================================

--- a/examples/entity-orchestration/package.json
+++ b/examples/entity-orchestration/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "ts-node --swc index.ts",
-    "start:emulator": "ENDPOINT=localhost:8080 TASKHUB=default ts-node --swc index.ts"
+    "start:emulator": "ENDPOINT=http://localhost:8080 TASKHUB=default ts-node --swc index.ts"
   },
   "dependencies": {
     "@microsoft/durabletask-js": "workspace:*",

--- a/examples/work-item-filters/index.ts
+++ b/examples/work-item-filters/index.ts
@@ -30,7 +30,7 @@ import {
   DurableTaskAzureManagedWorkerBuilder,
 } from "@microsoft/durabletask-js-azuremanaged";
 
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 // ============================================================================

--- a/examples/work-item-filters/package.json
+++ b/examples/work-item-filters/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "ts-node --swc index.ts",
-    "start:emulator": "ENDPOINT=localhost:8080 TASKHUB=default ts-node --swc index.ts"
+    "start:emulator": "ENDPOINT=http://localhost:8080 TASKHUB=default ts-node --swc index.ts"
   },
   "dependencies": {
     "@microsoft/durabletask-js": "workspace:*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2189,9 +2189,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
-      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha1-hOfN9jzaogwTSqMXzMkBqiHhbw4=",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/packages/durabletask-js-azuremanaged/CHANGELOG.md
+++ b/packages/durabletask-js-azuremanaged/CHANGELOG.md
@@ -8,11 +8,15 @@
 - Add `DurableTaskAzureManagedWorkerBuilder.channelRecreateFailureThreshold()` to control when
   consecutive likely-poisoned failures recreate the gRPC channel.
 
+### Breaking changes
+
+- Schemeless endpoints now default to HTTPS. Connection-string and builder `.endpoint(...)` users
+  must prefix plaintext local or emulator endpoints with `http://`.
+
 ### Fixes
 
 - Select TLS from the Azure-managed endpoint scheme independently of authentication, and require explicit opt-in
-  before sending token credentials over an insecure endpoint. Schemeless endpoints now default to HTTPS; local
-  plaintext endpoints must include the `http://` scheme.
+  before sending token credentials over an insecure endpoint.
 
 ## v0.4.0 (2026-07-31)
 

--- a/packages/durabletask-js-azuremanaged/CHANGELOG.md
+++ b/packages/durabletask-js-azuremanaged/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixes
 
+- Select TLS from the Azure-managed endpoint scheme independently of authentication, and require explicit opt-in
+  before sending token credentials over an insecure endpoint. Schemeless endpoints now default to HTTPS; local
+  plaintext endpoints must include the `http://` scheme.
+
 ## v0.4.0 (2026-07-31)
 
 ### Changes

--- a/packages/durabletask-js-azuremanaged/README.md
+++ b/packages/durabletask-js-azuremanaged/README.md
@@ -84,6 +84,16 @@ Endpoint transport and authentication are configured independently:
   `.allowInsecureCredentials(true)`. This opt-in permits authentication metadata over plaintext; it never
   downgrades an HTTPS endpoint.
 
+Because `connectionString()` replaces the builder's entire options object, all options configured before it are
+reset. Call subsequent option-setting methods after it:
+
+```typescript
+new DurableTaskAzureManagedClientBuilder()
+  .connectionString("Endpoint=http://localhost:8080;Authentication=DefaultAzure;TaskHub=myTaskHub")
+  .allowInsecureCredentials(true)
+  .build();
+```
+
 ## API Reference
 
 ### Classes

--- a/packages/durabletask-js-azuremanaged/README.md
+++ b/packages/durabletask-js-azuremanaged/README.md
@@ -84,8 +84,8 @@ Endpoint transport and authentication are configured independently:
   `.allowInsecureCredentials(true)`. This opt-in permits authentication metadata over plaintext; it never
   downgrades an HTTPS endpoint.
 
-Because `connectionString()` replaces the builder's entire options object, all options configured before it are
-reset. Call subsequent option-setting methods after it:
+Because `connectionString()` replaces the builder's connection-derived options, connection options configured
+before it are reset. Call subsequent option-setting methods after it:
 
 ```typescript
 new DurableTaskAzureManagedClientBuilder()

--- a/packages/durabletask-js-azuremanaged/README.md
+++ b/packages/durabletask-js-azuremanaged/README.md
@@ -84,8 +84,9 @@ Endpoint transport and authentication are configured independently:
   `.allowInsecureCredentials(true)`. This opt-in permits authentication metadata over plaintext; it never
   downgrades an HTTPS endpoint.
 
-Because `connectionString()` replaces the builder's entire options object, all options configured before it are
-reset. Call subsequent option-setting methods after it:
+`connectionString()` replaces only the Azure-managed connection options. Builder-level state such as the logger,
+gRPC channel options, and worker registrations is preserved. Connection options configured before it are reset, so
+`.allowInsecureCredentials(true)` must follow `.connectionString(...)`:
 
 ```typescript
 new DurableTaskAzureManagedClientBuilder()

--- a/packages/durabletask-js-azuremanaged/README.md
+++ b/packages/durabletask-js-azuremanaged/README.md
@@ -84,8 +84,8 @@ Endpoint transport and authentication are configured independently:
   `.allowInsecureCredentials(true)`. This opt-in permits authentication metadata over plaintext; it never
   downgrades an HTTPS endpoint.
 
-Because `connectionString()` replaces the builder's connection-derived options, connection options configured
-before it are reset. Call subsequent option-setting methods after it:
+Because `connectionString()` replaces the builder's entire options object, all options configured before it are
+reset. Call subsequent option-setting methods after it:
 
 ```typescript
 new DurableTaskAzureManagedClientBuilder()

--- a/packages/durabletask-js-azuremanaged/README.md
+++ b/packages/durabletask-js-azuremanaged/README.md
@@ -73,6 +73,17 @@ The connection string `Authentication` parameter supports the following values:
 Endpoint=<endpoint>;Authentication=<auth-type>;TaskHub=<task-hub-name>[;ClientID=<client-id>][;TenantId=<tenant-id>]
 ```
 
+## Transport Security
+
+Endpoint transport and authentication are configured independently:
+
+- `https://` endpoints always use TLS.
+- `http://` endpoints use plaintext and are intended for local development and testing.
+- Endpoints without a scheme default to HTTPS.
+- Token credentials with an HTTP endpoint are rejected unless the client or worker builder explicitly calls
+  `.allowInsecureCredentials(true)`. This opt-in permits authentication metadata over plaintext; it never
+  downgrades an HTTPS endpoint.
+
 ## API Reference
 
 ### Classes

--- a/packages/durabletask-js-azuremanaged/src/client-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/client-builder.ts
@@ -25,8 +25,8 @@ export class DurableTaskAzureManagedClientBuilder {
 
   /**
    * Configures the builder using a connection string.
-   * This replaces the entire options object and resets all previously configured options, so call it before
-   * subsequent option-setting methods.
+   * This replaces the Azure-managed connection options. Builder-level settings such as the logger and gRPC
+   * channel options are preserved. Call connection option setters after this method.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/client-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/client-builder.ts
@@ -35,9 +35,7 @@ export class DurableTaskAzureManagedClientBuilder {
       throw new Error("connectionString must not be null or empty");
     }
 
-    this._options = DurableTaskAzureManagedClientOptions.fromConnectionString(
-      connectionString,
-    ).setAllowInsecureCredentials(this._options.isAllowInsecureCredentials());
+    this._options = DurableTaskAzureManagedClientOptions.fromConnectionString(connectionString);
     return this;
   }
 

--- a/packages/durabletask-js-azuremanaged/src/client-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/client-builder.ts
@@ -25,6 +25,8 @@ export class DurableTaskAzureManagedClientBuilder {
 
   /**
    * Configures the builder using a connection string.
+   * This replaces the entire options object and resets all previously configured options, so call it before
+   * subsequent option-setting methods.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/client-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/client-builder.ts
@@ -25,7 +25,8 @@ export class DurableTaskAzureManagedClientBuilder {
 
   /**
    * Configures the builder using a connection string.
-   * This replaces the current connection-derived options, so call it before subsequent option-setting methods.
+   * This replaces the entire options object and resets all previously configured options, so call it before
+   * subsequent option-setting methods.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/client-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/client-builder.ts
@@ -25,8 +25,7 @@ export class DurableTaskAzureManagedClientBuilder {
 
   /**
    * Configures the builder using a connection string.
-   * This replaces the entire options object and resets all previously configured options, so call it before
-   * subsequent option-setting methods.
+   * This replaces the current connection-derived options, so call it before subsequent option-setting methods.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/client-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/client-builder.ts
@@ -35,7 +35,9 @@ export class DurableTaskAzureManagedClientBuilder {
       throw new Error("connectionString must not be null or empty");
     }
 
-    this._options = DurableTaskAzureManagedClientOptions.fromConnectionString(connectionString);
+    this._options = DurableTaskAzureManagedClientOptions.fromConnectionString(
+      connectionString,
+    ).setAllowInsecureCredentials(this._options.isAllowInsecureCredentials());
     return this;
   }
 
@@ -63,8 +65,7 @@ export class DurableTaskAzureManagedClientBuilder {
     this._options
       .setEndpointAddress(endpoint)
       .setTaskHubName(taskHubName)
-      .setCredential(credential ?? null)
-      .setAllowInsecureCredentials(credential === null || credential === undefined);
+      .setCredential(credential ?? null);
 
     return this;
   }
@@ -157,10 +158,15 @@ export class DurableTaskAzureManagedClientBuilder {
       ...this._grpcChannelOptions,
     };
 
-    // Use the core TaskHubGrpcClient with custom credentials and metadata generator
-    // For insecure connections, metadata is passed via the metadataGenerator parameter
-    // For secure connections, metadata is included in the channel credentials
-    return new TaskHubGrpcClient(hostAddress, combinedOptions, true, channelCredentials, metadataGenerator, this._logger);
+    // Use the core TaskHubGrpcClient with custom channel credentials and per-call metadata.
+    return new TaskHubGrpcClient(
+      hostAddress,
+      combinedOptions,
+      true,
+      channelCredentials,
+      metadataGenerator,
+      this._logger,
+    );
   }
 }
 

--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -96,7 +96,13 @@ abstract class DurableTaskAzureManagedOptionsBase {
   }
 
   private getEndpointUrl(): URL {
-    const endpoint = this._endpointAddress.includes("://") ? this._endpointAddress : `https://${this._endpointAddress}`;
+    const endpointAddress = this._endpointAddress.replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, "");
+    const schemeSeparator = /^[a-z][a-z\d+.-]*:([/\\]+)/i.exec(endpointAddress);
+    if (/[\t\n\f\r ]/.test(endpointAddress) || (schemeSeparator && schemeSeparator[1] !== "//")) {
+      throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
+    }
+
+    const endpoint = endpointAddress.includes("://") ? endpointAddress : `https://${endpointAddress}`;
 
     let url: URL;
     try {
@@ -107,6 +113,10 @@ abstract class DurableTaskAzureManagedOptionsBase {
 
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error(`Unsupported endpoint scheme '${url.protocol}'. Only HTTP and HTTPS are supported.`);
+    }
+
+    if (!url.hostname || url.username || url.password) {
+      throw new Error("Invalid endpoint URL: the endpoint must contain a hostname without user information.");
     }
 
     return url;

--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -115,8 +115,10 @@ abstract class DurableTaskAzureManagedOptionsBase {
    */
   getHostAddress(): string {
     const url = this.getEndpointUrl();
-    const port = url.port || (url.protocol === "http:" ? "80" : "");
-    return port ? `${url.hostname}:${port}` : url.hostname;
+    if (url.protocol === "http:" && !url.port) {
+      return `${url.hostname}:80`;
+    }
+    return url.host;
   }
 
   private getEndpointUrl(): URL {

--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -9,33 +9,6 @@ import { getCredentialFromAuthenticationType } from "./credential-factory";
 import { getUserAgent } from "./user-agent";
 import { ClientRetryOptions, createServiceConfig, DEFAULT_SERVICE_CONFIG } from "./retry-policy";
 
-function normalizeEndpointAddress(endpointAddress: string): string {
-  const endpoint = endpointAddress.replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, "");
-  if (/[\t\n\f\r ]/.test(endpoint)) {
-    throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
-  }
-
-  const schemeSeparatorIndex = endpoint.indexOf("://");
-  if (schemeSeparatorIndex === -1) {
-    if (endpoint.includes("/") || endpoint.includes("\\")) {
-      throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
-    }
-    return `https://${endpoint}`;
-  }
-
-  const scheme = endpoint.slice(0, schemeSeparatorIndex);
-  if (scheme.includes("/") || scheme.includes("\\")) {
-    throw new Error("Invalid endpoint URL: expected '://' immediately after the scheme.");
-  }
-
-  const firstHostnameCharacter = endpoint[schemeSeparatorIndex + 3];
-  if (!firstHostnameCharacter || firstHostnameCharacter === "/" || firstHostnameCharacter === "\\") {
-    throw new Error("Invalid endpoint URL: expected a hostname immediately after '://'.");
-  }
-
-  return endpoint;
-}
-
 /**
  * Base options for configuring the Azure-managed Durable Task service.
  * Contains properties common to both client and worker configurations.
@@ -122,7 +95,17 @@ abstract class DurableTaskAzureManagedOptionsBase {
   }
 
   private getEndpointUrl(): URL {
-    const endpoint = normalizeEndpointAddress(this._endpointAddress);
+    let endpoint = this._endpointAddress.trim();
+    if (/\s/.test(endpoint)) {
+      throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
+    }
+
+    if (!/^https?:\/\/[^/\\]/i.test(endpoint)) {
+      if (endpoint.includes("/") || endpoint.includes("\\")) {
+        throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
+      }
+      endpoint = `https://${endpoint}`;
+    }
 
     let url: URL;
     try {

--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -88,11 +88,8 @@ abstract class DurableTaskAzureManagedOptionsBase {
    */
   getHostAddress(): string {
     const url = this.getEndpointUrl();
-    let authority = url.hostname;
-    if (url.port) {
-      authority = `${authority}:${url.port}`;
-    }
-    return authority;
+    const port = url.port || (url.protocol === "http:" ? "80" : "");
+    return port ? `${url.hostname}:${port}` : url.hostname;
   }
 
   private getEndpointUrl(): URL {

--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -9,6 +9,33 @@ import { getCredentialFromAuthenticationType } from "./credential-factory";
 import { getUserAgent } from "./user-agent";
 import { ClientRetryOptions, createServiceConfig, DEFAULT_SERVICE_CONFIG } from "./retry-policy";
 
+function normalizeEndpointAddress(endpointAddress: string): string {
+  const endpoint = endpointAddress.replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, "");
+  if (/[\t\n\f\r ]/.test(endpoint)) {
+    throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
+  }
+
+  const schemeSeparatorIndex = endpoint.indexOf("://");
+  if (schemeSeparatorIndex === -1) {
+    if (endpoint.includes("/") || endpoint.includes("\\")) {
+      throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
+    }
+    return `https://${endpoint}`;
+  }
+
+  const scheme = endpoint.slice(0, schemeSeparatorIndex);
+  if (scheme.includes("/") || scheme.includes("\\")) {
+    throw new Error("Invalid endpoint URL: expected '://' immediately after the scheme.");
+  }
+
+  const firstHostnameCharacter = endpoint[schemeSeparatorIndex + 3];
+  if (!firstHostnameCharacter || firstHostnameCharacter === "/" || firstHostnameCharacter === "\\") {
+    throw new Error("Invalid endpoint URL: expected a hostname immediately after '://'.");
+  }
+
+  return endpoint;
+}
+
 /**
  * Base options for configuring the Azure-managed Durable Task service.
  * Contains properties common to both client and worker configurations.
@@ -93,13 +120,7 @@ abstract class DurableTaskAzureManagedOptionsBase {
   }
 
   private getEndpointUrl(): URL {
-    const endpointAddress = this._endpointAddress.replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, "");
-    const schemeSeparator = /^[a-z][a-z\d+.-]*:([/\\]+)/i.exec(endpointAddress);
-    if (/[\t\n\f\r ]/.test(endpointAddress) || (schemeSeparator && schemeSeparator[1] !== "//")) {
-      throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
-    }
-
-    const endpoint = endpointAddress.includes("://") ? endpointAddress : `https://${endpointAddress}`;
+    const endpoint = normalizeEndpointAddress(this._endpointAddress);
 
     let url: URL;
     try {

--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -87,23 +87,29 @@ abstract class DurableTaskAzureManagedOptionsBase {
    * @returns The normalized host address for gRPC connection.
    */
   getHostAddress(): string {
-    let endpoint = this._endpointAddress;
-
-    // Add https:// prefix if no protocol is specified
-    if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
-      endpoint = `https://${endpoint}`;
+    const url = this.getEndpointUrl();
+    let authority = url.hostname;
+    if (url.port) {
+      authority = `${authority}:${url.port}`;
     }
+    return authority;
+  }
 
+  private getEndpointUrl(): URL {
+    const endpoint = this._endpointAddress.includes("://") ? this._endpointAddress : `https://${this._endpointAddress}`;
+
+    let url: URL;
     try {
-      const url = new URL(endpoint);
-      let authority = url.hostname;
-      if (url.port) {
-        authority = `${authority}:${url.port}`;
-      }
-      return authority;
+      url = new URL(endpoint);
     } catch (e) {
       throw new Error(`Invalid endpoint URL: ${endpoint}`, { cause: e });
     }
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`Unsupported endpoint scheme '${url.protocol}'. Only HTTP and HTTPS are supported.`);
+    }
+
+    return url;
   }
 
   /**
@@ -111,13 +117,11 @@ abstract class DurableTaskAzureManagedOptionsBase {
    * @param callerType The type of caller for user-agent header.
    * @param workerId Optional worker ID (only for workers).
    */
-  protected createMetadataGeneratorInternal(
-    callerType: string,
-    workerId?: string,
-  ): () => Promise<grpc.Metadata> {
+  protected createMetadataGeneratorInternal(callerType: string, workerId?: string): () => Promise<grpc.Metadata> {
     // Create token cache only if credential is not null
     let tokenCache: AccessTokenCache | null = null;
     if (this._credential) {
+      this.validateTokenCredentialTransport(this.getEndpointUrl());
       const scope = this._resourceId + "/.default";
       tokenCache = new AccessTokenCache(this._credential, scope, this._tokenRefreshMargin);
     }
@@ -146,20 +150,29 @@ abstract class DurableTaskAzureManagedOptionsBase {
 
   /**
    * Creates gRPC channel credentials based on the configured options.
-   * For insecure connections, returns insecure credentials.
-   * For secure connections, returns SSL credentials.
+   * HTTPS endpoints use SSL credentials; HTTP endpoints use insecure credentials.
+   * Token credentials over an insecure endpoint require explicit opt-in.
    * Note: Metadata (taskhub, auth token, etc.) is passed per-call via the metadataGenerator
    * rather than being composed into the channel credentials. This ensures consistent behavior
    * across both secure and insecure connections.
    */
-  protected createChannelCredentialsInternal(_callerType: string, _workerId?: string): grpc.ChannelCredentials {
-    if (this._allowInsecureCredentials) {
-      return grpc.ChannelCredentials.createInsecure();
+  protected createChannelCredentialsInternal(): grpc.ChannelCredentials {
+    const endpoint = this.getEndpointUrl();
+    this.validateTokenCredentialTransport(endpoint);
+
+    if (endpoint.protocol.toLowerCase() === "https:") {
+      return grpc.ChannelCredentials.createSsl();
     }
 
-    // For secure connections, use SSL credentials
-    // Metadata is passed per-call via the client/worker's metadataGenerator parameter
-    return grpc.ChannelCredentials.createSsl();
+    return grpc.ChannelCredentials.createInsecure();
+  }
+
+  private validateTokenCredentialTransport(endpoint: URL): void {
+    if (endpoint.protocol === "http:" && this._credential && !this._allowInsecureCredentials) {
+      throw new Error(
+        "Token credentials cannot be used with an insecure endpoint unless allowInsecureCredentials(true) is configured.",
+      );
+    }
   }
 
   /**
@@ -169,9 +182,7 @@ abstract class DurableTaskAzureManagedOptionsBase {
     this._endpointAddress = connectionString.getEndpoint();
     this._taskHubName = connectionString.getTaskHubName();
 
-    const credential = getCredentialFromAuthenticationType(connectionString);
-    this._credential = credential;
-    this._allowInsecureCredentials = credential === null;
+    this._credential = getCredentialFromAuthenticationType(connectionString);
   }
 }
 
@@ -243,7 +254,7 @@ export class DurableTaskAzureManagedClientOptions extends DurableTaskAzureManage
   /**
    * Creates a gRPC channel metadata generator for per-call metadata.
    * Does NOT include workerid header (client only).
-   * This is used for insecure connections where metadata can't be added via channel credentials.
+   * This is used for both secure and insecure connections.
    */
   createMetadataGenerator(): () => Promise<grpc.Metadata> {
     return this.createMetadataGeneratorInternal("DurableTaskClient");
@@ -253,10 +264,10 @@ export class DurableTaskAzureManagedClientOptions extends DurableTaskAzureManage
    * Creates gRPC channel credentials for the client.
    * Does NOT include workerid header.
    * For insecure connections, returns just insecure credentials (use createMetadataGenerator for metadata).
-   * For secure connections, returns SSL credentials composed with call credentials.
+   * For secure connections, returns SSL credentials.
    */
   createChannelCredentials(): grpc.ChannelCredentials {
-    return this.createChannelCredentialsInternal("DurableTaskClient");
+    return this.createChannelCredentialsInternal();
   }
 }
 
@@ -354,7 +365,7 @@ export class DurableTaskAzureManagedWorkerOptions extends DurableTaskAzureManage
   /**
    * Creates a gRPC channel metadata generator for per-call metadata.
    * Includes workerid header (worker only).
-   * This is used for insecure connections where metadata can't be added via channel credentials.
+   * This is used for both secure and insecure connections.
    */
   createMetadataGenerator(): () => Promise<grpc.Metadata> {
     return this.createMetadataGeneratorInternal("DurableTaskWorker", this._workerId);
@@ -364,9 +375,9 @@ export class DurableTaskAzureManagedWorkerOptions extends DurableTaskAzureManage
    * Creates gRPC channel credentials for the worker.
    * Includes workerid header.
    * For insecure connections, returns just insecure credentials (use createMetadataGenerator for metadata).
-   * For secure connections, returns SSL credentials composed with call credentials.
+   * For secure connections, returns SSL credentials.
    */
   createChannelCredentials(): grpc.ChannelCredentials {
-    return this.createChannelCredentialsInternal("DurableTaskWorker", this._workerId);
+    return this.createChannelCredentialsInternal();
   }
 }

--- a/packages/durabletask-js-azuremanaged/src/options.ts
+++ b/packages/durabletask-js-azuremanaged/src/options.ts
@@ -101,7 +101,7 @@ abstract class DurableTaskAzureManagedOptionsBase {
     }
 
     if (!/^https?:\/\/[^/\\]/i.test(endpoint)) {
-      if (endpoint.includes("/") || endpoint.includes("\\")) {
+      if (/[/?#\\]/.test(endpoint)) {
         throw new Error("Invalid endpoint URL: expected an HTTP(S) URL or a schemeless authority.");
       }
       endpoint = `https://${endpoint}`;

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -53,9 +53,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
       throw new Error("connectionString must not be null or empty");
     }
 
-    this._options = DurableTaskAzureManagedWorkerOptions.fromConnectionString(
-      connectionString,
-    ).setAllowInsecureCredentials(this._options.isAllowInsecureCredentials());
+    this._options = DurableTaskAzureManagedWorkerOptions.fromConnectionString(connectionString);
     return this;
   }
 

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -53,7 +53,9 @@ export class DurableTaskAzureManagedWorkerBuilder {
       throw new Error("connectionString must not be null or empty");
     }
 
-    this._options = DurableTaskAzureManagedWorkerOptions.fromConnectionString(connectionString);
+    this._options = DurableTaskAzureManagedWorkerOptions.fromConnectionString(
+      connectionString,
+    ).setAllowInsecureCredentials(this._options.isAllowInsecureCredentials());
     return this;
   }
 
@@ -81,8 +83,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
     this._options
       .setEndpointAddress(endpoint)
       .setTaskHubName(taskHubName)
-      .setCredential(credential ?? null)
-      .setAllowInsecureCredentials(credential === null || credential === undefined);
+      .setCredential(credential ?? null);
 
     return this;
   }

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -43,7 +43,8 @@ export class DurableTaskAzureManagedWorkerBuilder {
 
   /**
    * Configures the builder using a connection string.
-   * This replaces the current connection-derived options, so call it before subsequent option-setting methods.
+   * This replaces the entire options object and resets all previously configured options, so call it before
+   * subsequent option-setting methods.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -43,6 +43,8 @@ export class DurableTaskAzureManagedWorkerBuilder {
 
   /**
    * Configures the builder using a connection string.
+   * This replaces the entire options object and resets all previously configured options, so call it before
+   * subsequent option-setting methods.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -43,8 +43,7 @@ export class DurableTaskAzureManagedWorkerBuilder {
 
   /**
    * Configures the builder using a connection string.
-   * This replaces the entire options object and resets all previously configured options, so call it before
-   * subsequent option-setting methods.
+   * This replaces the current connection-derived options, so call it before subsequent option-setting methods.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/src/worker-builder.ts
+++ b/packages/durabletask-js-azuremanaged/src/worker-builder.ts
@@ -43,8 +43,8 @@ export class DurableTaskAzureManagedWorkerBuilder {
 
   /**
    * Configures the builder using a connection string.
-   * This replaces the entire options object and resets all previously configured options, so call it before
-   * subsequent option-setting methods.
+   * This replaces the Azure-managed connection options. Worker registrations and builder-level settings are
+   * preserved. Call connection option setters after this method.
    *
    * @param connectionString The connection string for Azure-managed Durable Task service.
    * @returns This builder instance.

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -49,7 +49,13 @@ const builderFactories: BuilderFactory[] = [
   },
 ];
 
-const malformedSchemeEndpoints = ["htps:/scheduler.internal:8080", "http:/localhost:8080", "https:/example.com"];
+const malformedSchemeEndpoints = [
+  "htps:/scheduler.internal:8080",
+  "http:/localhost:8080",
+  "https:/example.com",
+  "https:/example.com/a://b",
+  "https:/\\example.com",
+];
 
 const silentlyRetargetedEndpoints = [
   "htt\nps:/example.com",

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -188,6 +188,21 @@ describe.each(builderFactories)("$name endpoint security", ({ create, fromConnec
   });
 });
 
+describe("grpc-js endpoint target", () => {
+  it("preserves the HTTP default port in the client channel target", () => {
+    const client = new DurableTaskAzureManagedClientBuilder()
+      .endpoint("http://localhost:80", "myTaskHub", null)
+      .build();
+
+    try {
+      const stub = (client as unknown as { _stub: { getChannel(): grpc.Channel } })._stub;
+      expect(stub.getChannel().getTarget()).toBe("dns:localhost:80");
+    } finally {
+      (client as unknown as { _stub: { close(): void } })._stub.close();
+    }
+  });
+});
+
 describe.each([
   {
     name: "client",
@@ -213,6 +228,13 @@ describe.each([
     ["[::1]:8080", "[::1]:8080"],
     ["HTTPS://EXAMPLE.COM", "example.com"],
     ["HTTP://LOCALHOST:8080", "localhost:8080"],
+    ["example.com:80", "example.com:80"],
+    ["http://example.com", "example.com:80"],
+    ["http://example.com:80", "example.com:80"],
+    ["http://example.com:8080", "example.com:8080"],
+    ["https://example.com", "example.com"],
+    ["https://example.com:443", "example.com"],
+    ["https://example.com:8443", "example.com:8443"],
     ["https://example.com/path?key=value#fragment", "example.com"],
     [" https://example.com \n", "example.com"],
     [" localhost:8080 ", "localhost:8080"],

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -135,14 +135,6 @@ describe.each(builderFactories)("$name endpoint security", ({ create, fromConnec
     expect((await getMetadata(value)).get("authorization")).toHaveLength(1);
   });
 
-  it("preserves explicit insecure credential opt-in across connection string configuration", () => {
-    expectInsecureChannel(
-      create()
-        .allowInsecureCredentials(true)
-        .connectionString("Endpoint=http://localhost:8080;Authentication=DefaultAzure;TaskHub=myTaskHub"),
-    );
-  });
-
   it("allows an HTTP token credential with explicit opt-in", async () => {
     const value = expectInsecureChannel(
       fromEndpoint("http://localhost:8080", new MockTokenCredential()).allowInsecureCredentials(true),

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -49,6 +49,16 @@ const builderFactories: BuilderFactory[] = [
   },
 ];
 
+const malformedSchemeEndpoints = ["htps:/scheduler.internal:8080", "http:/localhost:8080", "https:/example.com"];
+
+const silentlyRetargetedEndpoints = [
+  "htt\nps:/example.com",
+  "http:\t/localhost:8080",
+  "https://exa\nmple.com",
+  "https://user@example.com",
+  "https:///example.com",
+];
+
 describe.each(builderFactories)("$name endpoint security", ({ create, fromConnectionString, fromEndpoint }) => {
   const constructed: object[] = [];
 
@@ -115,6 +125,10 @@ describe.each(builderFactories)("$name endpoint security", ({ create, fromConnec
     expectSecureChannel(fromConnectionString("Endpoint=example.com;Authentication=None;TaskHub=myTaskHub"));
   });
 
+  it.each([" https://example.com ", " example.com "])("ignores outer whitespace in endpoint %s", (endpoint) => {
+    expectSecureChannel(fromEndpoint(endpoint, null));
+  });
+
   it("uses TLS with authorization metadata for an HTTPS token credential", async () => {
     const value = expectSecureChannel(fromEndpoint("https://example.com", new MockTokenCredential()));
 
@@ -152,18 +166,76 @@ describe.each(builderFactories)("$name endpoint security", ({ create, fromConnec
 
     expect(() => builder.build()).toThrow("Unsupported endpoint scheme");
   });
+
+  it.each(malformedSchemeEndpoints)("rejects malformed scheme endpoint %s before channel construction", (endpoint) => {
+    const createSsl = jest.spyOn(grpc.ChannelCredentials, "createSsl");
+    const createInsecure = jest.spyOn(grpc.ChannelCredentials, "createInsecure");
+    const builder = fromEndpoint(endpoint, new MockTokenCredential());
+
+    expect(() => builder.build()).toThrow("Invalid endpoint URL");
+    expect(createSsl).not.toHaveBeenCalled();
+    expect(createInsecure).not.toHaveBeenCalled();
+  });
+
+  it.each(silentlyRetargetedEndpoints)("rejects ambiguous endpoint %s before channel construction", (endpoint) => {
+    const createSsl = jest.spyOn(grpc.ChannelCredentials, "createSsl");
+    const createInsecure = jest.spyOn(grpc.ChannelCredentials, "createInsecure");
+    const builder = fromEndpoint(endpoint, new MockTokenCredential());
+
+    expect(() => builder.build()).toThrow("Invalid endpoint URL");
+    expect(createSsl).not.toHaveBeenCalled();
+    expect(createInsecure).not.toHaveBeenCalled();
+  });
 });
 
 describe.each([
   {
     name: "client",
+    create: (endpoint: string) => new DurableTaskAzureManagedClientOptions().setEndpointAddress(endpoint),
     fromConnectionString: DurableTaskAzureManagedClientOptions.fromConnectionString,
   },
   {
     name: "worker",
+    create: (endpoint: string) => new DurableTaskAzureManagedWorkerOptions().setEndpointAddress(endpoint),
     fromConnectionString: DurableTaskAzureManagedWorkerOptions.fromConnectionString,
   },
-])("$name options endpoint security", ({ fromConnectionString }) => {
+])("$name options endpoint security", ({ create, fromConnectionString }) => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ["example.com", "example.com"],
+    ["example.com:8443", "example.com:8443"],
+    ["localhost:8080", "localhost:8080"],
+    ["127.0.0.1:8080", "127.0.0.1:8080"],
+    ["[::1]", "[::1]"],
+    ["[::1]:8080", "[::1]:8080"],
+    ["HTTPS://EXAMPLE.COM", "example.com"],
+    ["HTTP://LOCALHOST:8080", "localhost:8080"],
+    ["https://example.com/path?key=value#fragment", "example.com"],
+    [" https://example.com \n", "example.com"],
+    [" localhost:8080 ", "localhost:8080"],
+  ])("normalizes supported endpoint %s to authority %s", (endpoint, authority) => {
+    expect(create(endpoint).getHostAddress()).toBe(authority);
+  });
+
+  it.each([...silentlyRetargetedEndpoints, "https://", "::1"])("rejects invalid endpoint %s", (endpoint) => {
+    expect(() => create(endpoint).getHostAddress()).toThrow("Invalid endpoint URL");
+  });
+
+  it.each(malformedSchemeEndpoints)("rejects malformed scheme endpoint %s before channel construction", (endpoint) => {
+    const createSsl = jest.spyOn(grpc.ChannelCredentials, "createSsl");
+    const createInsecure = jest.spyOn(grpc.ChannelCredentials, "createInsecure");
+    const options = fromConnectionString(`Endpoint=${endpoint};Authentication=None;TaskHub=myTaskHub`).setCredential(
+      new MockTokenCredential(),
+    );
+
+    expect(() => options.createChannelCredentials()).toThrow("Invalid endpoint URL");
+    expect(createSsl).not.toHaveBeenCalled();
+    expect(createInsecure).not.toHaveBeenCalled();
+  });
+
   it("does not infer insecure token consent from an anonymous connection string", () => {
     const options = fromConnectionString(
       "Endpoint=http://localhost:8080;Authentication=None;TaskHub=myTaskHub",

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/identity";
+import { AccessToken, DefaultAzureCredential, GetTokenOptions, TokenCredential } from "@azure/identity";
 import * as grpc from "@grpc/grpc-js";
 import { DurableTaskAzureManagedClientBuilder } from "../../src/client-builder";
 import { DurableTaskAzureManagedClientOptions, DurableTaskAzureManagedWorkerOptions } from "../../src/options";
@@ -155,6 +155,32 @@ describe.each(builderFactories)("$name endpoint security", ({ create, fromConnec
     );
 
     expect((await getMetadata(value)).get("authorization")).toEqual(["Bearer mock-token"]);
+  });
+
+  it("allows connection string HTTP credentials when opt-in follows connectionString", async () => {
+    jest.spyOn(DefaultAzureCredential.prototype, "getToken").mockResolvedValue({
+      token: "mock-token",
+      expiresOnTimestamp: Date.now() + 3600000,
+    });
+    const value = expectInsecureChannel(
+      create()
+        .connectionString("Endpoint=http://localhost:8080;Authentication=DefaultAzure;TaskHub=myTaskHub")
+        .allowInsecureCredentials(true),
+    );
+
+    expect((await getMetadata(value)).get("authorization")).toHaveLength(1);
+  });
+
+  it("resets insecure credential opt-in when connectionString follows it", () => {
+    const createSsl = jest.spyOn(grpc.ChannelCredentials, "createSsl");
+    const createInsecure = jest.spyOn(grpc.ChannelCredentials, "createInsecure");
+    const builder = create()
+      .allowInsecureCredentials(true)
+      .connectionString("Endpoint=http://localhost:8080;Authentication=DefaultAzure;TaskHub=myTaskHub");
+
+    expect(() => builder.build()).toThrow("allowInsecureCredentials(true)");
+    expect(createSsl).not.toHaveBeenCalled();
+    expect(createInsecure).not.toHaveBeenCalled();
   });
 
   it("does not let explicit insecure credential opt-in downgrade an HTTPS endpoint", () => {

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -193,10 +193,10 @@ describe.each(builderFactories)("$name endpoint security", ({ create, fromConnec
     expectSecureChannel(fromEndpoint("https://example.com", new MockTokenCredential()).allowInsecureCredentials(true));
   });
 
-  it("rejects unsupported endpoint schemes instead of using plaintext", () => {
+  it("rejects typo endpoint schemes instead of using plaintext", () => {
     const builder = fromConnectionString("Endpoint=htps://example.com;Authentication=None;TaskHub=myTaskHub");
 
-    expect(() => builder.build()).toThrow("Unsupported endpoint scheme");
+    expect(() => builder.build()).toThrow("Invalid endpoint URL");
   });
 
   it.each(malformedSchemeEndpoints)("rejects malformed scheme endpoint %s before channel construction", (endpoint) => {

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/identity";
+import * as grpc from "@grpc/grpc-js";
+import { DurableTaskAzureManagedClientBuilder } from "../../src/client-builder";
+import { DurableTaskAzureManagedClientOptions, DurableTaskAzureManagedWorkerOptions } from "../../src/options";
+import { DurableTaskAzureManagedWorkerBuilder } from "../../src/worker-builder";
+
+class MockTokenCredential implements TokenCredential {
+  async getToken(_scopes: string | string[], _options?: GetTokenOptions): Promise<AccessToken> {
+    return {
+      token: "mock-token",
+      expiresOnTimestamp: Date.now() + 3600000,
+    };
+  }
+}
+
+interface TestBuilder {
+  allowInsecureCredentials(allowInsecure: boolean): TestBuilder;
+  connectionString(connectionString: string): TestBuilder;
+  endpoint(endpoint: string, taskHubName: string, credential?: TokenCredential | null): TestBuilder;
+  build(): object;
+}
+
+interface BuilderFactory {
+  name: string;
+  create(): TestBuilder;
+  fromConnectionString(connectionString: string): TestBuilder;
+  fromEndpoint(endpoint: string, credential: TokenCredential | null): TestBuilder;
+}
+
+const builderFactories: BuilderFactory[] = [
+  {
+    name: "client",
+    create: () => new DurableTaskAzureManagedClientBuilder(),
+    fromConnectionString: (connectionString) =>
+      new DurableTaskAzureManagedClientBuilder().connectionString(connectionString),
+    fromEndpoint: (endpoint, credential) =>
+      new DurableTaskAzureManagedClientBuilder().endpoint(endpoint, "myTaskHub", credential),
+  },
+  {
+    name: "worker",
+    create: () => new DurableTaskAzureManagedWorkerBuilder(),
+    fromConnectionString: (connectionString) =>
+      new DurableTaskAzureManagedWorkerBuilder().connectionString(connectionString),
+    fromEndpoint: (endpoint, credential) =>
+      new DurableTaskAzureManagedWorkerBuilder().endpoint(endpoint, "myTaskHub", credential),
+  },
+];
+
+describe.each(builderFactories)("$name endpoint security", ({ create, fromConnectionString, fromEndpoint }) => {
+  const constructed: object[] = [];
+
+  afterEach(() => {
+    for (const value of constructed) {
+      const stub = (value as { _stub?: { close(): void } | null })._stub;
+      stub?.close();
+    }
+    constructed.length = 0;
+    jest.restoreAllMocks();
+  });
+
+  function buildAndCapture(builder: TestBuilder): object {
+    const value = builder.build();
+    constructed.push(value);
+    return value;
+  }
+
+  function expectSecureChannel(builder: TestBuilder): object {
+    const createSsl = jest.spyOn(grpc.ChannelCredentials, "createSsl");
+    const createInsecure = jest.spyOn(grpc.ChannelCredentials, "createInsecure");
+
+    const value = buildAndCapture(builder);
+
+    expect(createSsl).toHaveBeenCalledTimes(1);
+    expect(createInsecure).not.toHaveBeenCalled();
+    return value;
+  }
+
+  function expectInsecureChannel(builder: TestBuilder): object {
+    const createSsl = jest.spyOn(grpc.ChannelCredentials, "createSsl");
+    const createInsecure = jest.spyOn(grpc.ChannelCredentials, "createInsecure");
+
+    const value = buildAndCapture(builder);
+
+    expect(createInsecure).toHaveBeenCalledTimes(1);
+    expect(createSsl).not.toHaveBeenCalled();
+    return value;
+  }
+
+  async function getMetadata(value: object): Promise<grpc.Metadata> {
+    const generator = (value as { _metadataGenerator?: () => Promise<grpc.Metadata> })._metadataGenerator;
+    expect(generator).toBeDefined();
+    return generator!();
+  }
+
+  it("uses TLS without authorization metadata for an HTTPS anonymous connection string", async () => {
+    const value = expectSecureChannel(
+      fromConnectionString("Endpoint=https://example.com;Authentication=None;TaskHub=myTaskHub"),
+    );
+
+    expect((await getMetadata(value)).get("authorization")).toEqual([]);
+  });
+
+  it("uses plaintext without authorization metadata for an HTTP anonymous connection string", async () => {
+    const value = expectInsecureChannel(
+      fromConnectionString("Endpoint=http://localhost:8080;Authentication=None;TaskHub=myTaskHub"),
+    );
+
+    expect((await getMetadata(value)).get("authorization")).toEqual([]);
+  });
+
+  it("defaults an endpoint without a scheme to TLS", () => {
+    expectSecureChannel(fromConnectionString("Endpoint=example.com;Authentication=None;TaskHub=myTaskHub"));
+  });
+
+  it("uses TLS with authorization metadata for an HTTPS token credential", async () => {
+    const value = expectSecureChannel(fromEndpoint("https://example.com", new MockTokenCredential()));
+
+    expect((await getMetadata(value)).get("authorization")).toEqual(["Bearer mock-token"]);
+  });
+
+  it("rejects an HTTP token credential without explicit opt-in", () => {
+    const builder = fromEndpoint("http://localhost:8080", new MockTokenCredential());
+
+    expect(() => builder.build()).toThrow("allowInsecureCredentials(true)");
+  });
+
+  it("allows insecure credentials when explicit opt-in precedes endpoint configuration", async () => {
+    const value = expectInsecureChannel(
+      create().allowInsecureCredentials(true).endpoint("http://localhost:8080", "myTaskHub", new MockTokenCredential()),
+    );
+
+    expect((await getMetadata(value)).get("authorization")).toHaveLength(1);
+  });
+
+  it("preserves explicit insecure credential opt-in across connection string configuration", () => {
+    expectInsecureChannel(
+      create()
+        .allowInsecureCredentials(true)
+        .connectionString("Endpoint=http://localhost:8080;Authentication=DefaultAzure;TaskHub=myTaskHub"),
+    );
+  });
+
+  it("allows an HTTP token credential with explicit opt-in", async () => {
+    const value = expectInsecureChannel(
+      fromEndpoint("http://localhost:8080", new MockTokenCredential()).allowInsecureCredentials(true),
+    );
+
+    expect((await getMetadata(value)).get("authorization")).toEqual(["Bearer mock-token"]);
+  });
+
+  it("does not let explicit insecure credential opt-in downgrade an HTTPS endpoint", () => {
+    expectSecureChannel(fromEndpoint("https://example.com", new MockTokenCredential()).allowInsecureCredentials(true));
+  });
+
+  it("rejects unsupported endpoint schemes instead of using plaintext", () => {
+    const builder = fromConnectionString("Endpoint=htps://example.com;Authentication=None;TaskHub=myTaskHub");
+
+    expect(() => builder.build()).toThrow("Unsupported endpoint scheme");
+  });
+});
+
+describe.each([
+  {
+    name: "client",
+    fromConnectionString: DurableTaskAzureManagedClientOptions.fromConnectionString,
+  },
+  {
+    name: "worker",
+    fromConnectionString: DurableTaskAzureManagedWorkerOptions.fromConnectionString,
+  },
+])("$name options endpoint security", ({ fromConnectionString }) => {
+  it("does not infer insecure token consent from an anonymous connection string", () => {
+    const options = fromConnectionString(
+      "Endpoint=http://localhost:8080;Authentication=None;TaskHub=myTaskHub",
+    ).setCredential(new MockTokenCredential());
+
+    expect(() => options.createChannelCredentials()).toThrow("allowInsecureCredentials(true)");
+  });
+
+  it("does not emit token metadata after creating an anonymous insecure channel", () => {
+    const options = fromConnectionString("Endpoint=http://localhost:8080;Authentication=None;TaskHub=myTaskHub");
+    options.createChannelCredentials();
+    options.setCredential(new MockTokenCredential());
+
+    expect(() => options.createMetadataGenerator()).toThrow("allowInsecureCredentials(true)");
+  });
+});

--- a/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/endpoint-security.spec.ts
@@ -274,9 +274,12 @@ describe.each([
     expect(create(endpoint).getHostAddress()).toBe(authority);
   });
 
-  it.each([...silentlyRetargetedEndpoints, "https://", "::1"])("rejects invalid endpoint %s", (endpoint) => {
-    expect(() => create(endpoint).getHostAddress()).toThrow("Invalid endpoint URL");
-  });
+  it.each([...silentlyRetargetedEndpoints, "https://", "::1", "example.com?next=other.test", "example.com#fragment"])(
+    "rejects invalid endpoint %s",
+    (endpoint) => {
+      expect(() => create(endpoint).getHostAddress()).toThrow("Invalid endpoint URL");
+    },
+  );
 
   it.each(malformedSchemeEndpoints)("rejects malformed scheme endpoint %s before channel construction", (endpoint) => {
     const createSsl = jest.spyOn(grpc.ChannelCredentials, "createSsl");

--- a/packages/durabletask-js-azuremanaged/test/unit/worker-builder.spec.ts
+++ b/packages/durabletask-js-azuremanaged/test/unit/worker-builder.spec.ts
@@ -18,7 +18,7 @@ function createCounterEntity(): ITaskEntity {
 }
 
 describe("DurableTaskAzureManagedWorkerBuilder", () => {
-  const ENDPOINT = "localhost:8080";
+  const ENDPOINT = "http://localhost:8080";
   const TASKHUB = "test";
 
   describe("addEntity", () => {

--- a/scripts/test-e2e-azuremanaged.sh
+++ b/scripts/test-e2e-azuremanaged.sh
@@ -5,10 +5,10 @@
 # It expects the DTS emulator to be running at the specified endpoint.
 #
 # Environment variables:
-#   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+#   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
 #   - TASKHUB: The task hub name (default: default)
 
-ENDPOINT="${ENDPOINT:-localhost:8080}"
+ENDPOINT="${ENDPOINT:-http://localhost:8080}"
 TASKHUB="${TASKHUB:-default}"
 
 # Start the DTS emulator if it is not running yet

--- a/test/e2e-azuremanaged/entity.spec.ts
+++ b/test/e2e-azuremanaged/entity.spec.ts
@@ -13,7 +13,7 @@
  * Environment variables:
  *   - AZURE_DTS_CONNECTION_STRING: Connection string for real DTS (takes precedence)
  *     Example: Endpoint=https://your-scheduler.eastus.durabletask.io;Authentication=DefaultAzure;TaskHub=your-taskhub
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  */
 
@@ -37,7 +37,7 @@ import {
 // Read environment variables
 // Connection string takes precedence over endpoint/taskHub for real DTS
 const connectionString = process.env.AZURE_DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 // ============================================================================

--- a/test/e2e-azuremanaged/export-history.spec.ts
+++ b/test/e2e-azuremanaged/export-history.spec.ts
@@ -24,7 +24,7 @@
  *   - EXPORT_HISTORY_E2E: Set to "1" to enable these tests (default: skipped)
  *   - AZURE_DTS_CONNECTION_STRING: Connection string for real DTS (required)
  *     Example: Endpoint=https://your-scheduler.eastus.durabletask.io;Authentication=DefaultAzure;TaskHub=your-taskhub
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  *   - AZURE_STORAGE_CONNECTION_STRING: Connection string for Azure Blob Storage or Azurite
  *     (default: UseDevelopmentStorage=true)
@@ -60,7 +60,7 @@ import {
 
 // Read environment variables
 const connectionString = process.env.AZURE_DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 const storageConnectionString =
   process.env.AZURE_STORAGE_CONNECTION_STRING || "UseDevelopmentStorage=true";

--- a/test/e2e-azuremanaged/history.spec.ts
+++ b/test/e2e-azuremanaged/history.spec.ts
@@ -7,7 +7,7 @@
  * Environment variables (choose one):
  *   - DTS_CONNECTION_STRING: Full connection string (e.g., "Endpoint=https://...;Authentication=DefaultAzure;TaskHub=...")
  *   OR
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  */
 
@@ -38,7 +38,7 @@ import {
 
 // Read environment variables
 const connectionString = process.env.DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 function createClient(): TaskHubGrpcClient {

--- a/test/e2e-azuremanaged/orchestration-id-reuse-policy.spec.ts
+++ b/test/e2e-azuremanaged/orchestration-id-reuse-policy.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "@microsoft/durabletask-js-azuremanaged";
 
 const connectionString = process.env.DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 function createClient(): TaskHubGrpcClient {

--- a/test/e2e-azuremanaged/orchestration.spec.ts
+++ b/test/e2e-azuremanaged/orchestration.spec.ts
@@ -7,7 +7,7 @@
  * Environment variables (choose one):
  *   - DTS_CONNECTION_STRING: Full connection string (e.g., "Endpoint=https://...;Authentication=DefaultAzure;TaskHub=...")
  *   OR
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  */
 
@@ -36,7 +36,7 @@ import {
 
 // Read environment variables
 const connectionString = process.env.DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 function createClient(): TaskHubGrpcClient {

--- a/test/e2e-azuremanaged/query-apis.spec.ts
+++ b/test/e2e-azuremanaged/query-apis.spec.ts
@@ -10,7 +10,7 @@
  *
  * Example for emulator:
  *   docker run -i -p 8080:8080 -d mcr.microsoft.com/dts/dts-emulator:latest
- *   ENDPOINT=localhost:8080 TASKHUB=default npx jest query-apis.spec.ts
+ *   ENDPOINT=http://localhost:8080 TASKHUB=default npx jest query-apis.spec.ts
  *
  * Example for real DTS:
  *   DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=https://...;Authentication=DefaultAzure;TaskHub=th3" npx jest query-apis.spec.ts
@@ -33,7 +33,7 @@ import {
 
 // Read environment variables - support both connection string and endpoint/taskhub
 const connectionString = process.env.DURABLE_TASK_SCHEDULER_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 function createClient(): TaskHubGrpcClient {

--- a/test/e2e-azuremanaged/restart.spec.ts
+++ b/test/e2e-azuremanaged/restart.spec.ts
@@ -8,7 +8,7 @@
  *       docker run -i -p 8080:8080 -d mcr.microsoft.com/dts/dts-emulator:latest
  *
  * Environment variables:
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  *   - DURABLE_TASK_SCHEDULER_CONNECTION_STRING: Optional connection string for real Azure DTS
  */
@@ -27,7 +27,7 @@ import {
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Read environment variables
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 const connectionString = process.env.DURABLE_TASK_SCHEDULER_CONNECTION_STRING;
 

--- a/test/e2e-azuremanaged/retry-advanced.spec.ts
+++ b/test/e2e-azuremanaged/retry-advanced.spec.ts
@@ -12,7 +12,7 @@
  * Environment variables (choose one):
  *   - DTS_CONNECTION_STRING: Full connection string
  *   OR
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  */
 
@@ -32,7 +32,7 @@ import {
 
 // Read environment variables
 const connectionString = process.env.DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 function createClient(): TaskHubGrpcClient {

--- a/test/e2e-azuremanaged/retry-handler.spec.ts
+++ b/test/e2e-azuremanaged/retry-handler.spec.ts
@@ -14,7 +14,7 @@
  * Environment variables (choose one):
  *   - DTS_CONNECTION_STRING: Full connection string
  *   OR
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  */
 
@@ -37,7 +37,7 @@ import {
 
 // Read environment variables
 const connectionString = process.env.DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 function createClient(): TaskHubGrpcClient {

--- a/test/e2e-azuremanaged/rewind.spec.ts
+++ b/test/e2e-azuremanaged/rewind.spec.ts
@@ -10,7 +10,7 @@
  *
  * Example for emulator:
  *   docker run -i -p 8080:8080 -d mcr.microsoft.com/dts/dts-emulator:latest
- *   ENDPOINT=localhost:8080 TASKHUB=default npx jest rewind.spec.ts
+ *   ENDPOINT=http://localhost:8080 TASKHUB=default npx jest rewind.spec.ts
  *
  * Example for real DTS:
  *   DURABLE_TASK_SCHEDULER_CONNECTION_STRING="Endpoint=https://...;Authentication=DefaultAzure;TaskHub=th3" npx jest rewind.spec.ts
@@ -30,7 +30,7 @@ import {
 
 // Read environment variables - support both connection string and endpoint/taskhub
 const connectionString = process.env.DURABLE_TASK_SCHEDULER_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 /**

--- a/test/e2e-azuremanaged/work-item-filters.spec.ts
+++ b/test/e2e-azuremanaged/work-item-filters.spec.ts
@@ -12,7 +12,7 @@
  * Environment variables (choose one):
  *   - DTS_CONNECTION_STRING: Full connection string
  *   OR
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  */
 
@@ -31,7 +31,7 @@ import {
 } from "@microsoft/durabletask-js-azuremanaged";
 
 const connectionString = process.env.DTS_CONNECTION_STRING;
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 function createClient(): TaskHubGrpcClient {

--- a/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
+++ b/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
@@ -30,7 +30,8 @@ const taskHub = process.env.TASKHUB || "default";
 
 const EMULATOR_CONTAINER = "dts-emulator-stream-recovery-test";
 const EMULATOR_IMAGE = "mcr.microsoft.com/dts/dts-emulator:latest";
-const EMULATOR_PORT = new URL(endpoint).port || "8080";
+const endpointUrl = new URL(/^https?:\/\//i.test(endpoint) ? endpoint : `https://${endpoint}`);
+const EMULATOR_PORT = endpointUrl.port || (endpointUrl.protocol === "http:" ? "80" : "443");
 const WATCHDOG_TIMEOUT_MS = 10000;
 const WATCHDOG_EVENT_TIMEOUT_MS = 30000;
 const DISABLED_WATCHDOG_PAUSE_MS = WATCHDOG_TIMEOUT_MS + 5000;

--- a/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
+++ b/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
@@ -8,7 +8,7 @@
  * that stopping a worker cancels reconnect work from that worker run.
  *
  * Environment variables:
- *   - ENDPOINT: The endpoint for the DTS emulator (default: localhost:8080)
+ *   - ENDPOINT: The endpoint for the DTS emulator (default: http://localhost:8080)
  *   - TASKHUB: The task hub name (default: default)
  */
 
@@ -25,12 +25,12 @@ import {
   DurableTaskAzureManagedWorkerBuilder,
 } from "@microsoft/durabletask-js-azuremanaged";
 
-const endpoint = process.env.ENDPOINT || "localhost:8080";
+const endpoint = process.env.ENDPOINT || "http://localhost:8080";
 const taskHub = process.env.TASKHUB || "default";
 
 const EMULATOR_CONTAINER = "dts-emulator-stream-recovery-test";
 const EMULATOR_IMAGE = "mcr.microsoft.com/dts/dts-emulator:latest";
-const EMULATOR_PORT = endpoint.split(":")[1] || "8080";
+const EMULATOR_PORT = new URL(endpoint).port || "8080";
 const WATCHDOG_TIMEOUT_MS = 10000;
 const WATCHDOG_EVENT_TIMEOUT_MS = 30000;
 const DISABLED_WATCHDOG_PAUSE_MS = WATCHDOG_TIMEOUT_MS + 5000;

--- a/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
+++ b/test/e2e-azuremanaged/worker-stream-recovery.spec.ts
@@ -25,7 +25,7 @@ import {
   DurableTaskAzureManagedWorkerBuilder,
 } from "@microsoft/durabletask-js-azuremanaged";
 
-const endpoint = process.env.ENDPOINT || "http://localhost:8080";
+const endpoint = (process.env.ENDPOINT || "http://localhost:8080").trim();
 const taskHub = process.env.TASKHUB || "default";
 
 const EMULATOR_CONTAINER = "dts-emulator-stream-recovery-test";


### PR DESCRIPTION
## Summary

- Select gRPC TLS from the endpoint scheme independently of authentication, defaulting schemeless authorities to HTTPS and requiring explicit opt-in before token credentials can use HTTP.
- Reject malformed or ambiguous endpoint values while preserving explicit HTTP(S) URL paths, queries, fragments, hostname/port forms, localhost, IPv4, bracketed IPv6, and outer whitespace.
- Preserve HTTP's default port in grpc-js targets.
- Clarify that `connectionString()` replaces Azure-managed connection options only; builder-level state remains configured, while `.allowInsecureCredentials(true)` must follow `.connectionString(...)`.
- Make the worker stream-recovery E2E setup normalize schemeless endpoints and derive omitted ports from the protocol (80 for HTTP, 443 for HTTPS).
- Repair Node 24 CI's npm lock validation by updating only the root `@types/node` lock entry from 22.19.9 to 22.20.1. npm 11's current ideal-tree resolution selected 22.20.1 while the stale root lock entry remained at 22.19.9.

## Endpoint compatibility

Schemeless input is treated as an authority (`example.com`, `example.com:8443`), not as a URL path. Explicit HTTP(S) URLs may include paths, queries, and fragments (for example, `https://example.com/callback?next=https://other.test`). This matches the documented and pre-change contract without adding parser ambiguity.

## Validation (heads `3c695f8` and `f38313a`)

- Clean `npm ci`: passed with Node 24.14.0 / npm 11.9.0.
- Focused endpoint-security suite: 115 passed after authority-contract hardening.
- Azure-managed unit suite: 226 passed.
- Worker stream-recovery spec test-loaded for schemeless, HTTP omitted-port, HTTPS omitted-port, and explicit-port inputs; direct matrix resolved them to 443, 80, 443, and the explicit port respectively.
- Core package build: passed.
- Azure-managed package build: passed.
- ESLint for changed TypeScript files: passed.
- Prettier for all changed files: passed.
- `git diff --check`: passed.

No real Azure validation was performed because no Azure test credentials or resource configuration were available.
