### PR TITLE
fix: add bounded cancellable worker response delivery retries

### DIFF
--- a/.github/workflows/dts-e2e-tests.yaml
+++ b/.github/workflows/dts-e2e-tests.yaml
@@ -29,7 +29,7 @@ jobs:
           - name: "query-restart"
             pattern: "test/e2e-azuremanaged/query-apis.spec.ts test/e2e-azuremanaged/restart.spec.ts"
           - name: "retry-history-rewind"
-            pattern: "test/e2e-azuremanaged/retry-handler.spec.ts test/e2e-azuremanaged/retry-advanced.spec.ts test/e2e-azuremanaged/history.spec.ts test/e2e-azuremanaged/rewind.spec.ts"
+            pattern: "test/e2e-azuremanaged/retry-handler.spec.ts test/e2e-azuremanaged/retry-advanced.spec.ts test/e2e-azuremanaged/history.spec.ts test/e2e-azuremanaged/rewind.spec.ts test/e2e-azuremanaged/worker-response-delivery.spec.ts packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts"
           - name: "worker-recovery"
             pattern: "test/e2e-azuremanaged/worker-stream-recovery.spec.ts"
             manages-emulator: true
@@ -69,5 +69,7 @@ jobs:
         run: npm ci
 
       - name: ✅ Run E2E tests — ${{ matrix.test-group.name }}
+        env:
+          WORKER_DELIVERY_CONNECTION_STRING: "Endpoint=http://localhost:8080;Authentication=None;TaskHub=default"
         run: npx jest ${{ matrix.test-group.pattern }} --runInBand --detectOpenHandles
         timeout-minutes: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 ### Fixes
 
+- Retry worker completion and version-rejection abandon delivery on transient gRPC failures,
+  with ten total attempts and cancellable backoff. Retry the same response without rerunning user
+  code, preserve initial completion during graceful shutdown, and keep replaced channels alive
+  for pending delivery. Worker-owned retries replace transport retries on worker channels only.
 - Bound each worker sidecar hello attempt to 30 seconds, retry failed connections, and cancel
   pending hello calls and reconnect delays when the worker stops.
 - Align worker stream recovery with the .NET SDK: reconnect after 120 seconds without a message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@
 
 - Retry worker completion and version-rejection abandon delivery on transient gRPC failures,
   with ten total SDK attempts and cancellable backoff. Retry the same response without rerunning user
-  code, preserve initial completion during graceful shutdown, and keep replaced channels alive
-  for pending delivery. Existing transport retry settings are preserved; each SDK attempt can
-  include additional configured gRPC retries.
+  code, preserve initial completion during graceful shutdown, cancel pending metadata waits, and
+  keep replaced channels alive for pending delivery. Existing transport retry settings are preserved;
+  each SDK attempt can include additional configured gRPC retries.
 - Bound each worker sidecar hello attempt to 30 seconds, retry failed connections, and cancel
   pending hello calls and reconnect delays when the worker stops.
 - Align worker stream recovery with the .NET SDK: reconnect after 120 seconds without a message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@
 ### Fixes
 
 - Retry worker completion and version-rejection abandon delivery on transient gRPC failures,
-  with ten total attempts and cancellable backoff. Retry the same response without rerunning user
+  with ten total SDK attempts and cancellable backoff. Retry the same response without rerunning user
   code, preserve initial completion during graceful shutdown, and keep replaced channels alive
-  for pending delivery. Worker-owned retries replace transport retries on worker channels only.
+  for pending delivery. Existing transport retry settings are preserved; each SDK attempt can
+  include additional configured gRPC retries.
 - Bound each worker sidecar hello attempt to 30 seconds, retry failed connections, and cancel
   pending hello calls and reconnect delays when the worker stops.
 - Align worker stream recovery with the .NET SDK: reconnect after 120 seconds without a message

--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ reconnected work-item streams.
 
 You can find more samples in the [examples/azure-managed](./examples/azure-managed) directory.
 
+### Worker response delivery
+
+Workers retry completion responses for orchestrations, activities, and entities, including
+version-mismatch failure and abandon responses. The policy follows the .NET worker: ten total
+attempts for `UNAVAILABLE`, `UNKNOWN`, `DEADLINE_EXCEEDED`, or `INTERNAL`, with exponential
+backoff starting at 200 ms, capped at 15 seconds before adding 0-20% jitter. Other errors and
+exhausted attempts are reported through the existing worker error logs.
+
+Only delivery is retried: the response and completion token are reused, not the user code.
+This does not change the backend's at-least-once work-item delivery contract; a backend may
+redeliver work after a lock expires or an acknowledgement is lost.
+
+`stop()` cancels retry delays and retried RPCs. Already-running work can still send its first
+completion during the existing graceful-shutdown window (`shutdownTimeoutMs`, default 30 seconds);
+remaining completion RPCs are cancelled when that window expires. Replaced worker channels stay
+open until their pending work finishes or shutdown forces cleanup.
+
+To avoid multiplying retry budgets, worker-created channels disable gRPC transport retries even
+when channel options or an Azure-managed service config enable them. The worker's own hello/stream
+reconnect loop remains active. Client channels and Azure-managed client retry configuration are unchanged.
+
 ### Reusing orchestration instance IDs
 
 Set the top-level `dedupeStatuses` start option when an instance ID may be reused. The list

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ redeliver work after a lock expires or an acknowledgement is lost.
 `stop()` cancels retry delays and retried RPCs. Already-running work can still send its first
 completion during the existing graceful-shutdown window (`shutdownTimeoutMs`, default 30 seconds);
 remaining completion RPCs are cancelled when that window expires. Replaced worker channels stay
-open until their pending work finishes or shutdown forces cleanup.
+open until their pending work finishes or shutdown forces cleanup. Cancellation also stops waiting
+for response metadata. A metadata generator may continue running, but its late result cannot start an RPC.
 
 Existing channel options and Azure-managed transport retry configuration are preserved, matching
 the .NET Azure-managed worker. Each SDK attempt can therefore contain additional gRPC transport

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can find more samples in the [examples/azure-managed](./examples/azure-manag
 
 Workers retry completion responses for orchestrations, activities, and entities, including
 version-mismatch failure and abandon responses. The policy follows the .NET worker: ten total
-attempts for `UNAVAILABLE`, `UNKNOWN`, `DEADLINE_EXCEEDED`, or `INTERNAL`, with exponential
+SDK attempts for `UNAVAILABLE`, `UNKNOWN`, `DEADLINE_EXCEEDED`, or `INTERNAL`, with exponential
 backoff starting at 200 ms, capped at 15 seconds before adding 0-20% jitter. Other errors and
 exhausted attempts are reported through the existing worker error logs.
 
@@ -124,9 +124,12 @@ completion during the existing graceful-shutdown window (`shutdownTimeoutMs`, de
 remaining completion RPCs are cancelled when that window expires. Replaced worker channels stay
 open until their pending work finishes or shutdown forces cleanup.
 
-To avoid multiplying retry budgets, worker-created channels disable gRPC transport retries even
-when channel options or an Azure-managed service config enable them. The worker's own hello/stream
-reconnect loop remains active. Client channels and Azure-managed client retry configuration are unchanged.
+Existing channel options and Azure-managed transport retry configuration are preserved, matching
+the .NET Azure-managed worker. Each SDK attempt can therefore contain additional gRPC transport
+retries: ten SDK attempts is not a ten-network-attempt guarantee. For example, a channel policy
+allowing five attempts can produce up to fifty attempts across the two configured retry layers.
+Configure channel retries with that combined budget in mind. The worker's hello/stream reconnect
+loop and client retry behavior remain unchanged.
 
 ### Reusing orchestration instance IDs
 

--- a/packages/durabletask-js/src/utils/backoff.util.ts
+++ b/packages/durabletask-js/src/utils/backoff.util.ts
@@ -37,10 +37,11 @@ export interface BackoffOptions {
 
   /**
    * Jitter distribution. "symmetric" preserves the default range around the delay;
-   * "full" selects uniformly from zero through the exponential upper bound.
+   * "full" selects uniformly from zero through the exponential upper bound;
+   * "positive" adds jitter above the delay, matching .NET worker delivery retries.
    * @default "symmetric"
    */
-  jitterStrategy?: "symmetric" | "full";
+  jitterStrategy?: "symmetric" | "full" | "positive";
 }
 
 /**
@@ -80,7 +81,7 @@ export class ExponentialBackoff {
   private readonly _multiplier: number;
   private readonly _maxAttempts: number;
   private readonly _jitterFactor: number;
-  private readonly _jitterStrategy: "symmetric" | "full";
+  private readonly _jitterStrategy: "symmetric" | "full" | "positive";
 
   private _currentDelayMs: number;
   private _attemptCount: number;
@@ -135,6 +136,9 @@ export class ExponentialBackoff {
     }
 
     const jitterRange = this._currentDelayMs * this._jitterFactor;
+    if (this._jitterStrategy === "positive") {
+      return Math.floor(this._currentDelayMs + Math.random() * jitterRange);
+    }
     const jitter = Math.random() * jitterRange * 2 - jitterRange;
     return Math.max(0, Math.floor(this._currentDelayMs + jitter));
   }

--- a/packages/durabletask-js/src/utils/grpc-helper.util.ts
+++ b/packages/durabletask-js/src/utils/grpc-helper.util.ts
@@ -14,7 +14,7 @@ export type MetadataGenerator = () => Promise<grpc.Metadata>;
  * @param method The gRPC method to call (must be bound to the stub).
  * @param req The request object.
  * @param metadataGenerator Optional function to generate metadata for the call.
- * @param signal Optional signal that cancels the call.
+ * @param signal Optional signal that cancels waiting for metadata and the call.
  * @returns A promise that resolves with the response or rejects with an error.
  */
 export async function callWithMetadata<TReq, TRes>(
@@ -27,7 +27,6 @@ export async function callWithMetadata<TReq, TRes>(
   metadataGenerator?: MetadataGenerator,
   signal?: AbortSignal,
 ): Promise<TRes> {
-  const metadata = metadataGenerator ? await metadataGenerator() : new grpc.Metadata();
   if (signal?.aborted) {
     throw signal.reason;
   }
@@ -41,13 +40,21 @@ export async function callWithMetadata<TReq, TRes>(
         call?.cancel();
       };
       signal?.addEventListener("abort", onAbort, { once: true });
-      call = method(req, metadata, (error, response) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(response);
+      const invoke = async () => {
+        const metadata = metadataGenerator ? await metadataGenerator() : new grpc.Metadata();
+        // Metadata generation may finish after cancellation; never start a late RPC.
+        if (signal?.aborted) {
+          throw signal.reason;
         }
-      });
+        call = method(req, metadata, (error, response) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(response);
+          }
+        });
+      };
+      invoke().catch(reject);
     });
   } finally {
     signal?.removeEventListener("abort", onAbort);

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -949,6 +949,7 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
     method: Parameters<typeof callWithMetadata<TReq, TRes>>[0],
     request: TReq,
+    signal?: AbortSignal,
   ): Promise<TRes> {
     const signals = this._responseDeliverySignals.get(stub);
     const backoff = new ExponentialBackoff({
@@ -960,9 +961,9 @@ export class TaskHubGrpcWorker {
     });
     for (;;) {
       try {
-        // Let draining work send its initial response; stop() cancels retries immediately.
-        const signal = backoff.attemptCount === 0 ? signals?.completion : signals?.retry;
-        return await callWithMetadata(method, request, this._metadataGenerator, signal);
+        // Default initial delivery can drain; an explicit signal cancels every attempt.
+        const attemptSignal = signal ?? (backoff.attemptCount === 0 ? signals?.completion : signals?.retry);
+        return await callWithMetadata(method, request, this._metadataGenerator, attemptSignal);
       } catch (error) {
         const status = error instanceof Error ? this._getGrpcStatus(error) : undefined;
         if (
@@ -974,9 +975,19 @@ export class TaskHubGrpcWorker {
         ) {
           throw error;
         }
-        await backoff.wait(signals?.retry);
+        await backoff.wait(signal ?? signals?.retry);
       }
     }
+  }
+
+  private async _abandonOrchestrationWorkItem(
+    stub: stubs.TaskHubSidecarServiceClient,
+    completionToken: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const request = new pb.AbandonOrchestrationTaskRequest();
+    request.setCompletiontoken(completionToken);
+    await this._deliverResponse(stub, stub.abandonTaskOrchestratorWorkItem.bind(stub), request, signal);
   }
 
   /**
@@ -1055,9 +1066,7 @@ export class TaskHubGrpcWorker {
         );
 
         try {
-          const abandonRequest = new pb.AbandonOrchestrationTaskRequest();
-          abandonRequest.setCompletiontoken(completionToken);
-          await this._deliverResponse(stub, stub.abandonTaskOrchestratorWorkItem.bind(stub), abandonRequest);
+          await this._abandonOrchestrationWorkItem(stub, completionToken);
         } catch (e: unknown) {
           const error = e instanceof Error ? e : new Error(String(e));
           WorkerLogs.completionError(this._logger, instanceId, error);

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -66,7 +66,7 @@ type WorkItemStreamResult = {
 export interface TaskHubGrpcWorkerOptions {
   /** The host address to connect to. Defaults to "localhost:4001". */
   hostAddress?: string;
-  /** gRPC channel options. Transport retries are disabled; the worker owns reconnect and response delivery retries. */
+  /** gRPC channel options. */
   options?: grpc.ChannelOptions;
   /** Whether to use TLS. Defaults to false. */
   useTLS?: boolean;
@@ -214,8 +214,7 @@ export class TaskHubGrpcWorker {
     this._registry = new Registry();
     this._hostAddress = resolvedHostAddress;
     this._tls = resolvedUseTLS;
-    // The worker owns the retry budget, including when an Azure-managed service config is supplied.
-    this._grpcChannelOptions = { ...resolvedOptions, "grpc.enable_retries": 0 };
+    this._grpcChannelOptions = resolvedOptions;
     this._grpcChannelCredentials = resolvedCredentials;
     this._metadataGenerator = resolvedMetadataGenerator;
     this._responseStream = null;
@@ -955,7 +954,7 @@ export class TaskHubGrpcWorker {
     const backoff = new ExponentialBackoff({
       initialDelayMs: 200,
       maxDelayMs: 15000,
-      maxAttempts: 9, // Ten total attempts, including the initial delivery.
+      maxAttempts: 9, // Ten SDK attempts; each call retains any configured gRPC transport retries.
       jitterStrategy: "positive",
       jitterFactor: 0.2,
     });

--- a/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
+++ b/packages/durabletask-js/src/worker/task-hub-grpc-worker.ts
@@ -4,6 +4,7 @@
 import * as pb from "../proto/orchestrator_service_pb";
 import * as stubs from "../proto/orchestrator_service_grpc_pb";
 import * as grpc from "@grpc/grpc-js";
+import { setMaxListeners } from "events";
 import { Registry } from "./registry";
 import { TActivity } from "../types/activity.type";
 import { TInput } from "../types/input.type";
@@ -49,6 +50,11 @@ const MAX_TIMER_DELAY_MS = 2_147_483_646;
 const MAX_PROTOCOL_CONCURRENCY = 2_147_483_647;
 const HELLO_TIMEOUT_MS = 30000;
 
+type ResponseDeliverySignals = {
+  completion: AbortSignal;
+  retry: AbortSignal;
+};
+
 type WorkItemStreamResult = {
   outcome: "shutdown" | "silentDisconnect" | "gracefulDrain";
   firstMessageObserved: boolean;
@@ -60,7 +66,7 @@ type WorkItemStreamResult = {
 export interface TaskHubGrpcWorkerOptions {
   /** The host address to connect to. Defaults to "localhost:4001". */
   hostAddress?: string;
-  /** gRPC channel options. */
+  /** gRPC channel options. Transport retries are disabled; the worker owns reconnect and response delivery retries. */
   options?: grpc.ChannelOptions;
   /** Whether to use TLS. Defaults to false. */
   useTLS?: boolean;
@@ -114,6 +120,7 @@ export class TaskHubGrpcWorker {
   private _stub: stubs.TaskHubSidecarServiceClient | null;
   private _logger: Logger;
   private _pendingWorkItems: Set<Promise<void>>;
+  private _pendingWorkItemsByStub = new WeakMap<stubs.TaskHubSidecarServiceClient, Set<Promise<void>>>();
   private _shutdownTimeoutMs: number;
   private _silentDisconnectTimeoutMs: number;
   private _silentDisconnectTimer: ReturnType<typeof setTimeout> | null;
@@ -123,6 +130,8 @@ export class TaskHubGrpcWorker {
   private _workItemFilters?: WorkItemFilters | "auto";
   private _concurrency: ResolvedConcurrencyOptions;
   private _abortController: AbortController | null;
+  private _completionAbortController: AbortController | null;
+  private _responseDeliverySignals = new WeakMap<stubs.TaskHubSidecarServiceClient, ResponseDeliverySignals>();
   private _workerLoopPromise: Promise<void> | null;
   private _deferredStubCloseTimers: Map<stubs.TaskHubSidecarServiceClient, ReturnType<typeof setTimeout>>;
 
@@ -205,7 +214,8 @@ export class TaskHubGrpcWorker {
     this._registry = new Registry();
     this._hostAddress = resolvedHostAddress;
     this._tls = resolvedUseTLS;
-    this._grpcChannelOptions = resolvedOptions;
+    // The worker owns the retry budget, including when an Azure-managed service config is supplied.
+    this._grpcChannelOptions = { ...resolvedOptions, "grpc.enable_retries": 0 };
     this._grpcChannelCredentials = resolvedCredentials;
     this._metadataGenerator = resolvedMetadataGenerator;
     this._responseStream = null;
@@ -239,6 +249,7 @@ export class TaskHubGrpcWorker {
     this._workItemFilters = resolvedWorkItemFilters;
     this._concurrency = resolveConcurrencyOptions(resolvedConcurrency);
     this._abortController = null;
+    this._completionAbortController = null;
     this._workerLoopPromise = null;
     this._deferredStubCloseTimers = new Map();
   }
@@ -426,8 +437,16 @@ export class TaskHubGrpcWorker {
     this._backoff.reset();
     const abortController = new AbortController();
     this._abortController = abortController;
+    const completionAbortController = new AbortController();
+    this._completionAbortController = completionAbortController;
+    // A run can have many concurrent response deliveries; each removes its listener when settled.
+    setMaxListeners(0, abortController.signal, completionAbortController.signal);
     const client = new GrpcClient(this._hostAddress, this._grpcChannelOptions, this._tls, this._grpcChannelCredentials);
     this._stub = client.stub;
+    this._responseDeliverySignals.set(client.stub, {
+      completion: completionAbortController.signal,
+      retry: abortController.signal,
+    });
 
     const workerLoopPromise = this.internalRunWorker(client, abortController.signal);
     this._workerLoopPromise = workerLoopPromise;
@@ -540,6 +559,10 @@ export class TaskHubGrpcWorker {
             continue;
           }
           this._stub = client.stub;
+          const deliverySignals = this._responseDeliverySignals.get(previousStub);
+          if (deliverySignals) {
+            this._responseDeliverySignals.set(client.stub, deliverySignals);
+          }
           WorkerLogs.channelRecreated(this._logger, this._hostAddress ?? "localhost:4001");
           consecutiveChannelFailures = 0;
           this._backoff.reset();
@@ -566,9 +589,15 @@ export class TaskHubGrpcWorker {
   }
 
   private _deferStubClose(stub: stubs.TaskHubSidecarServiceClient): void {
+    const pendingWork = [...(this._pendingWorkItemsByStub.get(stub) ?? [])];
     const timer = setTimeout(() => {
-      this._deferredStubCloseTimers.delete(stub);
-      stub.close();
+      // Delivery retries may outlive the retirement delay. Keep their original stub alive.
+      void Promise.all(pendingWork).then(() => {
+        if (this._deferredStubCloseTimers.get(stub) === timer) {
+          this._deferredStubCloseTimers.delete(stub);
+          stub.close();
+        }
+      });
     }, DEFERRED_STUB_CLOSE_DELAY_MS);
     timer.unref();
     this._deferredStubCloseTimers.set(stub, timer);
@@ -761,6 +790,7 @@ export class TaskHubGrpcWorker {
       }
     }
 
+    this._completionAbortController?.abort();
     this._closeDeferredStubs();
     if (this._stub) {
       // Close the gRPC client - this is a synchronous operation
@@ -892,7 +922,16 @@ export class TaskHubGrpcWorker {
     return undefined;
   }
 
-  private _trackPendingWorkItem(workPromise: Promise<void>, onError: (error: Error) => void): void {
+  private _trackPendingWorkItem(
+    stub: stubs.TaskHubSidecarServiceClient,
+    workPromise: Promise<void>,
+    onError: (error: Error) => void,
+  ): void {
+    let stubWorkItems = this._pendingWorkItemsByStub.get(stub);
+    if (!stubWorkItems) {
+      stubWorkItems = new Set();
+      this._pendingWorkItemsByStub.set(stub, stubWorkItems);
+    }
     const handledPromise = workPromise
       .catch((e: unknown) => {
         const error = e instanceof Error ? e : new Error(String(e));
@@ -900,9 +939,45 @@ export class TaskHubGrpcWorker {
       })
       .finally(() => {
         this._pendingWorkItems.delete(handledPromise);
+        stubWorkItems.delete(handledPromise);
       });
 
     this._pendingWorkItems.add(handledPromise);
+    stubWorkItems.add(handledPromise);
+  }
+
+  private async _deliverResponse<TReq, TRes>(
+    stub: stubs.TaskHubSidecarServiceClient,
+    method: Parameters<typeof callWithMetadata<TReq, TRes>>[0],
+    request: TReq,
+  ): Promise<TRes> {
+    const signals = this._responseDeliverySignals.get(stub);
+    const backoff = new ExponentialBackoff({
+      initialDelayMs: 200,
+      maxDelayMs: 15000,
+      maxAttempts: 9, // Ten total attempts, including the initial delivery.
+      jitterStrategy: "positive",
+      jitterFactor: 0.2,
+    });
+    for (;;) {
+      try {
+        // Let draining work send its initial response; stop() cancels retries immediately.
+        const signal = backoff.attemptCount === 0 ? signals?.completion : signals?.retry;
+        return await callWithMetadata(method, request, this._metadataGenerator, signal);
+      } catch (error) {
+        const status = error instanceof Error ? this._getGrpcStatus(error) : undefined;
+        if (
+          !backoff.canRetry() ||
+          (status !== grpc.status.UNAVAILABLE &&
+            status !== grpc.status.UNKNOWN &&
+            status !== grpc.status.DEADLINE_EXCEEDED &&
+            status !== grpc.status.INTERNAL)
+        ) {
+          throw error;
+        }
+        await backoff.wait(signals?.retry);
+      }
+    }
   }
 
   /**
@@ -914,7 +989,7 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
   ): void {
     const workPromise = this._executeOrchestratorInternal(req, completionToken, stub);
-    this._trackPendingWorkItem(workPromise, (error) => {
+    this._trackPendingWorkItem(stub, workPromise, (error) => {
       WorkerLogs.executionError(this._logger, req.getInstanceid() || "(unknown)", error);
     });
   }
@@ -965,7 +1040,7 @@ export class TaskHubGrpcWorker {
         res.setActionsList(actions);
 
         try {
-          await callWithMetadata(stub.completeOrchestratorTask.bind(stub), res, this._metadataGenerator);
+          await this._deliverResponse(stub, stub.completeOrchestratorTask.bind(stub), res);
         } catch (e: unknown) {
           const error = e instanceof Error ? e : new Error(String(e));
           WorkerLogs.completionError(this._logger, instanceId, error);
@@ -983,11 +1058,7 @@ export class TaskHubGrpcWorker {
         try {
           const abandonRequest = new pb.AbandonOrchestrationTaskRequest();
           abandonRequest.setCompletiontoken(completionToken);
-          await callWithMetadata(
-            stub.abandonTaskOrchestratorWorkItem.bind(stub),
-            abandonRequest,
-            this._metadataGenerator,
-          );
+          await this._deliverResponse(stub, stub.abandonTaskOrchestratorWorkItem.bind(stub), abandonRequest);
         } catch (e: unknown) {
           const error = e instanceof Error ? e : new Error(String(e));
           WorkerLogs.completionError(this._logger, instanceId, error);
@@ -1094,7 +1165,7 @@ export class TaskHubGrpcWorker {
     }
 
     try {
-      await callWithMetadata(stub.completeOrchestratorTask.bind(stub), res, this._metadataGenerator);
+      await this._deliverResponse(stub, stub.completeOrchestratorTask.bind(stub), res);
     } catch (e: unknown) {
       const error = e instanceof Error ? e : new Error(String(e));
       WorkerLogs.completionError(this._logger, req.getInstanceid(), error);
@@ -1110,7 +1181,7 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
   ): void {
     const workPromise = this._executeActivityInternal(req, completionToken, stub);
-    this._trackPendingWorkItem(workPromise, (error) => {
+    this._trackPendingWorkItem(stub, workPromise, (error) => {
       WorkerLogs.workerError(this._logger, error);
     });
   }
@@ -1175,7 +1246,7 @@ export class TaskHubGrpcWorker {
     }
 
     try {
-      await callWithMetadata(stub.completeActivityTask.bind(stub), res, this._metadataGenerator);
+      await this._deliverResponse(stub, stub.completeActivityTask.bind(stub), res);
     } catch (e: unknown) {
       const error = e instanceof Error ? e : new Error(String(e));
       WorkerLogs.activityResponseError(this._logger, req.getName(), req.getTaskid(), instanceId!, error);
@@ -1192,7 +1263,7 @@ export class TaskHubGrpcWorker {
     operationInfos?: pb.OperationInfo[],
   ): void {
     const workPromise = this._executeEntityInternal(req, completionToken, stub, operationInfos);
-    this._trackPendingWorkItem(workPromise, (error) => {
+    this._trackPendingWorkItem(stub, workPromise, (error) => {
       WorkerLogs.workerError(this._logger, error);
     });
   }
@@ -1293,7 +1364,7 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
   ): void {
     const workPromise = this._executeEntityV2Internal(req, completionToken, stub);
-    this._trackPendingWorkItem(workPromise, (error) => {
+    this._trackPendingWorkItem(stub, workPromise, (error) => {
       WorkerLogs.workerError(this._logger, error);
     });
   }
@@ -1449,7 +1520,7 @@ export class TaskHubGrpcWorker {
     stub: stubs.TaskHubSidecarServiceClient,
   ): Promise<void> {
     try {
-      await callWithMetadata(stub.completeEntityTask.bind(stub), batchResult, this._metadataGenerator);
+      await this._deliverResponse(stub, stub.completeEntityTask.bind(stub), batchResult);
     } catch (e: any) {
       WorkerLogs.entityResponseDeliveryFailed(this._logger, e);
     }

--- a/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
@@ -172,7 +172,7 @@ describe("Worker response delivery over gRPC", () => {
     expect(logger.error).toHaveBeenCalledTimes(1);
   });
 
-  it("caps delivery at ten server calls even with all-method channel retries configured", async () => {
+  it("bounds SDK delivery to ten attempts while preserving configured transport retries", async () => {
     const wait = ExponentialBackoff.prototype.wait;
     jest.spyOn(ExponentialBackoff.prototype, "wait").mockImplementation(function (
       this: ExponentialBackoff,
@@ -214,12 +214,14 @@ describe("Worker response delivery over gRPC", () => {
         },
       },
     );
+    const sdkDeliveries = jest.spyOn(worker!["_stub"]!, "completeActivityTask");
     stream.write(activityWorkItem());
     expect(await withTimeout(terminalError.promise, 5000)).toContain("INTERNAL");
     await drainWork();
 
-    expect(requests).toHaveLength(10);
-    expect(transportAttempts).toEqual(Array.from({ length: 10 }, () => []));
+    expect(sdkDeliveries).toHaveBeenCalledTimes(10);
+    expect(requests).toHaveLength(50);
+    expect(transportAttempts).toEqual(Array.from({ length: 10 }, () => [[], ["1"], ["2"], ["3"], ["4"]]).flat());
     expect(requests.every((request) => request.getCompletiontoken() === "delivery-token")).toBe(true);
     expect(requests.every((request) => request.getResult()?.getValue() === '"activity-result"')).toBe(true);
     expect(activity).toHaveBeenCalledTimes(1);

--- a/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
@@ -1,0 +1,514 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as grpc from "@grpc/grpc-js";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
+import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
+import { TaskEntity } from "../src/entities/task-entity";
+import * as stubs from "../src/proto/orchestrator_service_grpc_pb";
+import * as pb from "../src/proto/orchestrator_service_pb";
+import { Logger } from "../src/types/logger.type";
+import { ExponentialBackoff, withTimeout } from "../src/utils/backoff.util";
+import { TaskHubGrpcWorker, TaskHubGrpcWorkerOptions } from "../src/worker/task-hub-grpc-worker";
+import { VersionFailureStrategy, VersionMatchStrategy } from "../src/worker/versioning-options";
+
+type WorkStream = grpc.ServerWritableStream<pb.GetWorkItemsRequest, pb.WorkItem>;
+type SidecarHandlers = Partial<
+  Pick<
+    stubs.ITaskHubSidecarServiceServer,
+    | "hello"
+    | "getWorkItems"
+    | "completeActivityTask"
+    | "completeOrchestratorTask"
+    | "completeEntityTask"
+    | "abandonTaskOrchestratorWorkItem"
+  >
+>;
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => (resolve = complete));
+  return { promise, resolve };
+}
+
+function grpcError(code: grpc.status): grpc.ServiceError {
+  return Object.assign(new Error("injected delivery failure"), {
+    code,
+    details: "injected delivery failure",
+    metadata: new grpc.Metadata(),
+  });
+}
+
+function activityWorkItem(): pb.WorkItem {
+  const request = new pb.ActivityRequest()
+    .setName("deliveryActivity")
+    .setTaskid(42)
+    .setOrchestrationinstance(new pb.OrchestrationInstance().setInstanceid("delivery-instance"));
+  return new pb.WorkItem().setCompletiontoken("delivery-token").setActivityrequest(request);
+}
+
+describe("Worker response delivery over gRPC", () => {
+  let server: grpc.Server;
+  let worker: TaskHubGrpcWorker | undefined;
+  let logger: Logger;
+  let activity: jest.Mock<Promise<string>, []>;
+  let firstStream: ReturnType<typeof deferred<WorkStream>>;
+  let terminalError: ReturnType<typeof deferred<string>>;
+  let shutdownWaiting: ReturnType<typeof deferred<void>>;
+
+  beforeEach(() => {
+    server = new grpc.Server();
+    worker = undefined;
+    activity = jest.fn(async () => "activity-result");
+    firstStream = deferred<WorkStream>();
+    terminalError = deferred<string>();
+    shutdownWaiting = deferred();
+    logger = {
+      error: jest.fn((message: string) => {
+        if (message.includes("Failed to deliver activity response")) terminalError.resolve(message);
+      }),
+      warn: jest.fn(),
+      info: jest.fn((message: string) => {
+        if (message.includes("pending work item(s) to complete")) shutdownWaiting.resolve();
+      }),
+      debug: jest.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    try {
+      if (worker?.["_isRunning"]) await withTimeout(worker.stop(), 5000);
+    } finally {
+      server.forceShutdown();
+      jest.restoreAllMocks();
+    }
+  });
+
+  async function startWorker(
+    handlers: SidecarHandlers,
+    options: TaskHubGrpcWorkerOptions = {},
+    register?: (worker: TaskHubGrpcWorker) => void,
+  ): Promise<WorkStream> {
+    server.addService(stubs.TaskHubSidecarServiceService, {
+      hello: (_call: grpc.ServerUnaryCall<Empty, Empty>, callback: grpc.sendUnaryData<Empty>) =>
+        callback(null, new Empty()),
+      getWorkItems: (call: WorkStream) => {
+        call.once("cancelled", () => call.end());
+        call.write(new pb.WorkItem().setHealthping(new pb.HealthPing()));
+        firstStream.resolve(call);
+      },
+      ...handlers,
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.bindAsync("127.0.0.1:0", grpc.ServerCredentials.createInsecure(), (error, boundPort) =>
+        error ? reject(error) : resolve(boundPort),
+      );
+    });
+    worker = new TaskHubGrpcWorker({
+      hostAddress: `127.0.0.1:${port}`,
+      logger,
+      shutdownTimeoutMs: 1000,
+      ...options,
+    });
+    worker.addNamedActivity("deliveryActivity", activity);
+    register?.(worker);
+    await worker.start();
+    return withTimeout(firstStream.promise, 5000, "Worker did not open its work-item stream");
+  }
+
+  async function drainWork(): Promise<void> {
+    await withTimeout(Promise.all(worker!["_pendingWorkItems"]), 5000, "Response delivery did not finish");
+    expect(worker!["_pendingWorkItems"].size).toBe(0);
+  }
+
+  it.each([grpc.status.INTERNAL, grpc.status.UNKNOWN, grpc.status.UNAVAILABLE, grpc.status.DEADLINE_EXCEEDED])(
+    "recovers status %s after committed headers without re-executing the activity",
+    async (code) => {
+      const requests: pb.ActivityResponse[] = [];
+      const accepted = deferred();
+      const stream = await startWorker({
+        completeActivityTask: (call, callback) => {
+          requests.push(call.request);
+          // Committed headers prohibit gRPC's transparent/service-config retries.
+          call.sendMetadata(new grpc.Metadata());
+          if (requests.length === 1) callback(grpcError(code));
+          else {
+            callback(null, new pb.CompleteTaskResponse());
+            accepted.resolve();
+          }
+        },
+      });
+      stream.write(activityWorkItem());
+      await withTimeout(accepted.promise, 5000);
+      await drainWork();
+
+      expect(requests).toHaveLength(2);
+      expect(requests[1].serializeBinary()).toEqual(requests[0].serializeBinary());
+      expect(requests[1].getCompletiontoken()).toBe("delivery-token");
+      expect(requests[1].getResult()?.getValue()).toBe('"activity-result"');
+      expect(requests[1].getTaskid()).toBe(42);
+      expect(requests[1].getInstanceid()).toBe("delivery-instance");
+      expect(activity).toHaveBeenCalledTimes(1);
+      expect(logger.error).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports a permanent failure once without retrying or re-executing", async () => {
+    const requests: pb.ActivityResponse[] = [];
+    const stream = await startWorker({
+      completeActivityTask: (call, callback) => {
+        requests.push(call.request);
+        callback(grpcError(grpc.status.INVALID_ARGUMENT));
+      },
+    });
+    stream.write(activityWorkItem());
+
+    expect(await withTimeout(terminalError.promise, 5000)).toContain("INVALID_ARGUMENT");
+    await drainWork();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].getCompletiontoken()).toBe("delivery-token");
+    expect(activity).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps delivery at ten server calls even with all-method channel retries configured", async () => {
+    const wait = ExponentialBackoff.prototype.wait;
+    jest.spyOn(ExponentialBackoff.prototype, "wait").mockImplementation(function (
+      this: ExponentialBackoff,
+      signal,
+      onDelay,
+    ) {
+      // Shorten only response delays, retaining the real wait and retry accounting.
+      if (this["_initialDelayMs"] === 200) this["_currentDelayMs"] = 1;
+      return wait.call(this, signal, onDelay);
+    });
+    const requests: pb.ActivityResponse[] = [];
+    const transportAttempts: grpc.MetadataValue[][] = [];
+    const stream = await startWorker(
+      {
+        completeActivityTask: (call, callback) => {
+          requests.push(call.request);
+          transportAttempts.push(call.metadata.get("grpc-previous-rpc-attempts"));
+          // Trailers-only errors would be eligible for the configured channel retry policy.
+          callback(grpcError(grpc.status.INTERNAL));
+        },
+      },
+      {
+        options: {
+          "grpc.enable_retries": 1,
+          "grpc.service_config": JSON.stringify({
+            methodConfig: [
+              {
+                name: [{}],
+                retryPolicy: {
+                  maxAttempts: 5,
+                  initialBackoff: "0.001s",
+                  maxBackoff: "0.001s",
+                  backoffMultiplier: 1,
+                  retryableStatusCodes: ["INTERNAL"],
+                },
+              },
+            ],
+          }),
+        },
+      },
+    );
+    stream.write(activityWorkItem());
+    expect(await withTimeout(terminalError.promise, 5000)).toContain("INTERNAL");
+    await drainWork();
+
+    expect(requests).toHaveLength(10);
+    expect(transportAttempts).toEqual(Array.from({ length: 10 }, () => []));
+    expect(requests.every((request) => request.getCompletiontoken() === "delivery-token")).toBe(true);
+    expect(requests.every((request) => request.getResult()?.getValue() === '"activity-result"')).toBe(true);
+    expect(activity).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["delay", "RPC"] as const)("stop cancels a retry %s without subsequent attempts", async (phase) => {
+    const retryWaiting = deferred();
+    const retriedCall = deferred();
+    const cancelled = deferred();
+    const wait = ExponentialBackoff.prototype.wait;
+    jest.spyOn(ExponentialBackoff.prototype, "wait").mockImplementation(function (
+      this: ExponentialBackoff,
+      signal,
+      onDelay,
+    ) {
+      const waiting = wait.call(this, signal, onDelay);
+      if (this["_initialDelayMs"] === 200) retryWaiting.resolve();
+      return waiting;
+    });
+    let attempts = 0;
+    const stream = await startWorker({
+      completeActivityTask: (call, callback) => {
+        if (++attempts === 1) callback(grpcError(grpc.status.INTERNAL));
+        else {
+          call.once("cancelled", () => cancelled.resolve());
+          retriedCall.resolve();
+        }
+      },
+    });
+    stream.write(activityWorkItem());
+    await withTimeout(phase === "delay" ? retryWaiting.promise : retriedCall.promise, 5000);
+
+    const stopping = worker!.stop();
+    if (phase === "RPC") await withTimeout(cancelled.promise, 5000, "Retried RPC was not cancelled");
+    await withTimeout(stopping, 5000);
+    await drainWork();
+    expect(attempts).toBe(phase === "delay" ? 1 : 2);
+    expect(activity).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("Shutdown timed out"));
+    expect(worker!["_stub"]!.getChannel().getConnectivityState(false)).toBe(grpc.connectivityState.SHUTDOWN);
+  });
+
+  it("graceful stop retains the stub until running activity work sends its initial completion", async () => {
+    const started = deferred();
+    const finishActivity = deferred<string>();
+    const received = deferred<grpc.sendUnaryData<pb.CompleteTaskResponse>>();
+    const requests: pb.ActivityResponse[] = [];
+    activity.mockImplementation(() => {
+      started.resolve();
+      return finishActivity.promise;
+    });
+    const stream = await startWorker(
+      {
+        completeActivityTask: (call, callback) => {
+          requests.push(call.request);
+          received.resolve(callback);
+        },
+      },
+      { shutdownTimeoutMs: 3000 },
+    );
+    const close = jest.spyOn(worker!["_stub"]!, "close");
+    stream.write(activityWorkItem());
+    await withTimeout(started.promise, 5000);
+
+    const stopping = worker!.stop();
+    await withTimeout(shutdownWaiting.promise, 5000);
+    expect(close).not.toHaveBeenCalled();
+    finishActivity.resolve("drained-result");
+    const complete = await withTimeout(received.promise, 5000);
+    expect(close).not.toHaveBeenCalled();
+    complete(null, new pb.CompleteTaskResponse());
+    await withTimeout(stopping, 5000);
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].getCompletiontoken()).toBe("delivery-token");
+    expect(requests[0].getResult()?.getValue()).toBe('"drained-result"');
+    expect(activity).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+    await drainWork();
+  });
+
+  it("shutdown timeout cancels an initial completion RPC that never responds", async () => {
+    const received = deferred<grpc.ServerUnaryCall<pb.ActivityResponse, pb.CompleteTaskResponse>>();
+    const cancelled = deferred();
+    let attempts = 0;
+    const stream = await startWorker(
+      {
+        completeActivityTask: (call) => {
+          attempts++;
+          call.once("cancelled", () => cancelled.resolve());
+          received.resolve(call);
+        },
+      },
+      { shutdownTimeoutMs: 100 },
+    );
+    stream.write(activityWorkItem());
+    const call = await withTimeout(received.promise, 5000);
+
+    const stopping = worker!.stop();
+    await withTimeout(shutdownWaiting.promise, 5000);
+    expect(call.cancelled).toBe(false);
+    await withTimeout(cancelled.promise, 5000, "Initial RPC was not cancelled after shutdown timeout");
+    await withTimeout(stopping, 5000);
+    await drainWork();
+
+    expect(attempts).toBe(1);
+    expect(activity).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Shutdown timed out after 100ms"));
+    expect(worker!["_stub"]!.getChannel().getConnectivityState(false)).toBe(grpc.connectivityState.SHUTDOWN);
+  });
+
+  it.each(["orchestrator", "entity-v1", "entity-v2", "version-fail", "abandon"] as const)(
+    "recovers the same %s completion payload without executing user code again",
+    async (kind) => {
+      const executed = jest.fn();
+      const versionMismatch = kind === "version-fail" || kind === "abandon";
+      type Response = pb.OrchestratorResponse | pb.EntityBatchResult | pb.AbandonOrchestrationTaskRequest;
+      const requests: Response[] = [];
+      const accepted = deferred();
+      const complete = <TResponse>(
+        call: grpc.ServerUnaryCall<Response, TResponse>,
+        callback: grpc.sendUnaryData<TResponse>,
+        response: TResponse,
+      ) => {
+        requests.push(call.request);
+        call.sendMetadata(new grpc.Metadata());
+        if (requests.length === 1) callback(grpcError(grpc.status.INTERNAL));
+        else {
+          callback(null, response);
+          accepted.resolve();
+        }
+      };
+      const stream = await startWorker(
+        {
+          completeOrchestratorTask: (call, callback) => complete(call, callback, new pb.CompleteTaskResponse()),
+          completeEntityTask: (call, callback) => complete(call, callback, new pb.CompleteTaskResponse()),
+          abandonTaskOrchestratorWorkItem: (call, callback) =>
+            complete(call, callback, new pb.AbandonOrchestrationTaskResponse()),
+        },
+        {
+          versioning: versionMismatch
+            ? {
+                version: "2",
+                matchStrategy: VersionMatchStrategy.Strict,
+                failureStrategy: kind === "abandon" ? VersionFailureStrategy.Reject : VersionFailureStrategy.Fail,
+              }
+            : undefined,
+        },
+        (worker) => {
+          worker.addNamedOrchestrator("deliveryOrchestrator", async () => {
+            executed();
+            return "orchestration-result";
+          });
+          class Counter extends TaskEntity<number> {
+            increment(): number {
+              executed();
+              return ++this.state;
+            }
+            protected initializeState(): number {
+              return 0;
+            }
+          }
+          worker.addNamedEntity("deliveryCounter", () => new Counter());
+        },
+      );
+      const item = new pb.WorkItem().setCompletiontoken("work-token");
+      if (kind === "orchestrator" || versionMismatch) {
+        const request = new pb.OrchestratorRequest().setInstanceid("delivery-instance");
+        request.setNeweventsList([
+          new pb.HistoryEvent()
+            .setTimestamp(Timestamp.fromDate(new Date("2026-01-01T00:00:00Z")))
+            .setOrchestratorstarted(new pb.OrchestratorStartedEvent()),
+          new pb.HistoryEvent().setExecutionstarted(
+            new pb.ExecutionStartedEvent().setName("deliveryOrchestrator").setVersion(new StringValue().setValue("1")),
+          ),
+        ]);
+        item.setOrchestratorrequest(request);
+      } else if (kind === "entity-v1") {
+        item.setEntityrequest(
+          new pb.EntityBatchRequest()
+            .setInstanceid("@deliverycounter@key")
+            .setOperationsList([new pb.OperationRequest().setOperation("increment").setRequestid("req-1")]),
+        );
+      } else {
+        item.setEntityrequestv2(
+          new pb.EntityRequest()
+            .setInstanceid("@deliverycounter@key")
+            .setOperationrequestsList([
+              new pb.HistoryEvent().setEntityoperationsignaled(
+                new pb.EntityOperationSignaledEvent().setOperation("increment").setRequestid("req-1"),
+              ),
+            ]),
+        );
+      }
+      stream.write(item);
+      await withTimeout(accepted.promise, 5000);
+      await drainWork();
+
+      expect(requests).toHaveLength(2);
+      expect(requests[1].serializeBinary()).toEqual(requests[0].serializeBinary());
+      expect(requests[1].getCompletiontoken()).toBe("work-token");
+      const response = requests[1];
+      expect(response).toBeInstanceOf(
+        kind === "abandon"
+          ? pb.AbandonOrchestrationTaskRequest
+          : kind.startsWith("entity")
+            ? pb.EntityBatchResult
+            : pb.OrchestratorResponse,
+      );
+      if (response instanceof pb.OrchestratorResponse) {
+        expect(response.getInstanceid()).toBe("delivery-instance");
+        expect(response.getActionsList()).toHaveLength(1);
+        const completion = response.getActionsList()[0].getCompleteorchestration();
+        if (kind === "version-fail") {
+          expect(completion?.getOrchestrationstatus()).toBe(pb.OrchestrationStatus.ORCHESTRATION_STATUS_FAILED);
+          expect(completion?.getFailuredetails()?.getErrortype()).toBe("VersionMismatch");
+          expect(completion?.getFailuredetails()?.getIsnonretriable()).toBe(true);
+        } else {
+          expect(completion?.getResult()?.getValue()).toBe('"orchestration-result"');
+        }
+      } else if (response instanceof pb.EntityBatchResult) {
+        expect(response.getEntitystate()?.getValue()).toBe("1");
+        expect(response.getResultsList()).toHaveLength(1);
+        expect(response.getResultsList()[0].getSuccess()?.getResult()?.getValue()).toBe("1");
+      }
+      expect(executed).toHaveBeenCalledTimes(versionMismatch ? 0 : 1);
+      expect(logger.error).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reconnects through hello and cancels a retried completion on its original stub", async () => {
+    const secondStream = deferred();
+    const started = deferred();
+    const finishActivity = deferred<string>();
+    const retriedCall = deferred();
+    const cancelled = deferred();
+    let helloCalls = 0;
+    let streamCalls = 0;
+    let attempts = 0;
+    activity.mockImplementation(() => {
+      started.resolve();
+      return finishActivity.promise;
+    });
+    const stream = await startWorker(
+      {
+        hello: (_call, callback) => {
+          helloCalls++;
+          callback(null, new Empty());
+        },
+        getWorkItems: (call) => {
+          call.once("cancelled", () => call.end());
+          call.write(new pb.WorkItem().setHealthping(new pb.HealthPing()));
+          if (++streamCalls === 1) firstStream.resolve(call);
+          else secondStream.resolve();
+        },
+        completeActivityTask: (call, callback) => {
+          if (++attempts === 1) callback(grpcError(grpc.status.INTERNAL));
+          else {
+            call.once("cancelled", () => cancelled.resolve());
+            retriedCall.resolve();
+          }
+        },
+      },
+      { channelRecreateFailureThreshold: 1 },
+    );
+    const originalStub = worker!["_stub"]!;
+    const close = jest.spyOn(originalStub, "close");
+    stream.write(activityWorkItem());
+    await withTimeout(started.promise, 5000);
+    stream.emit("error", grpcError(grpc.status.UNAVAILABLE));
+    await withTimeout(secondStream.promise, 5000, "Worker did not reconnect");
+    expect(worker!["_stub"]).not.toBe(originalStub);
+    expect(close).not.toHaveBeenCalled();
+
+    finishActivity.resolve("original-stub-result");
+    await withTimeout(retriedCall.promise, 5000);
+    const stopping = worker!.stop();
+    await withTimeout(cancelled.promise, 5000, "Retired stub RPC was not cancelled");
+    await withTimeout(stopping, 5000);
+    await drainWork();
+
+    expect(helloCalls).toBe(2);
+    expect(streamCalls).toBe(2);
+    expect(attempts).toBe(2);
+    expect(activity).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("Shutdown timed out"));
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(worker!["_deferredStubCloseTimers"].size).toBe(0);
+  });
+});

--- a/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
@@ -265,6 +265,59 @@ describe("Worker response delivery over gRPC", () => {
     expect(worker!["_stub"]!.getChannel().getConnectivityState(false)).toBe(grpc.connectivityState.SHUTDOWN);
   });
 
+  it.each(["initial", "retry"] as const)("stop settles pending %s metadata without a late RPC", async (phase) => {
+    const metadata = deferred<grpc.Metadata>();
+    const metadataWaiting = deferred();
+    let holdMetadata = false;
+    let received = 0;
+    const stream = await startWorker(
+      {
+        completeActivityTask: (call, callback) => {
+          received++;
+          holdMetadata = true;
+          call.sendMetadata(new grpc.Metadata());
+          callback(grpcError(grpc.status.INTERNAL));
+        },
+      },
+      {
+        shutdownTimeoutMs: phase === "initial" ? 100 : 3000,
+        metadataGenerator: async () => {
+          if (holdMetadata) {
+            metadataWaiting.resolve();
+            return metadata.promise;
+          }
+          return new grpc.Metadata();
+        },
+      },
+    );
+    holdMetadata = phase === "initial";
+    const send = jest.spyOn(worker!["_stub"]!, "completeActivityTask");
+    stream.write(activityWorkItem());
+    await withTimeout(metadataWaiting.promise, 5000);
+    const pending = Promise.all(worker!["_pendingWorkItems"]);
+    const stopping = worker!.stop();
+    try {
+      if (phase === "initial") {
+        await withTimeout(shutdownWaiting.promise, 5000);
+        expect(worker!["_completionAbortController"]!.signal.aborted).toBe(false);
+        expect(worker!["_pendingWorkItems"].size).toBe(1);
+      }
+      await withTimeout(pending, 1000, "Metadata wait did not settle on cancellation");
+      await withTimeout(stopping, 5000);
+      await drainWork();
+
+      metadata.resolve(new grpc.Metadata());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(send).toHaveBeenCalledTimes(phase === "initial" ? 0 : 1);
+      expect(received).toBe(phase === "initial" ? 0 : 1);
+      expect(activity).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledTimes(phase === "initial" ? 1 : 0);
+    } finally {
+      metadata.resolve(new grpc.Metadata());
+      await withTimeout(stopping, 5000);
+    }
+  });
+
   it("graceful stop retains the stub until running activity work sends its initial completion", async () => {
     const started = deferred();
     const finishActivity = deferred<string>();

--- a/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery-grpc.spec.ts
@@ -172,6 +172,77 @@ describe("Worker response delivery over gRPC", () => {
     expect(logger.error).toHaveBeenCalledTimes(1);
   });
 
+  it("retries explicit-signal abandonment with the same completion token", async () => {
+    const requests: pb.AbandonOrchestrationTaskRequest[] = [];
+    await startWorker({
+      abandonTaskOrchestratorWorkItem: (call, callback) => {
+        requests.push(call.request);
+        call.sendMetadata(new grpc.Metadata());
+        if (requests.length === 1) callback(grpcError(grpc.status.INTERNAL));
+        else callback(null, new pb.AbandonOrchestrationTaskResponse());
+      },
+    });
+    const controller = new AbortController();
+    await withTimeout(
+      worker!["_abandonOrchestrationWorkItem"](worker!["_stub"]!, "explicit-abandon-token", controller.signal),
+      5000,
+    );
+    expect(requests).toHaveLength(2);
+    expect(requests[1].serializeBinary()).toEqual(requests[0].serializeBinary());
+    expect(requests[1].getCompletiontoken()).toBe("explicit-abandon-token");
+    expect(activity).not.toHaveBeenCalled();
+  });
+
+  it.each(["metadata", "RPC"])("explicit abandonment cancellation stops initial %s immediately", async (phase) => {
+    const metadata = deferred<grpc.Metadata>();
+    const started = deferred();
+    const cancelled = deferred();
+    let holdMetadata = false;
+    await startWorker(
+      {
+        abandonTaskOrchestratorWorkItem: (call) => {
+          call.once("cancelled", () => cancelled.resolve());
+          started.resolve();
+        },
+      },
+      {
+        metadataGenerator: async () => {
+          if (holdMetadata) {
+            started.resolve();
+            return metadata.promise;
+          }
+          return new grpc.Metadata();
+        },
+      },
+    );
+    holdMetadata = phase === "metadata";
+    const send = jest.spyOn(worker!["_stub"]!, "abandonTaskOrchestratorWorkItem");
+    const controller = new AbortController();
+    const reason = new Error("abandonment cancelled");
+    const delivery = worker!["_abandonOrchestrationWorkItem"](
+      worker!["_stub"]!,
+      "explicit-abandon-token",
+      controller.signal,
+    );
+    const rejection = expect(delivery).rejects.toBe(reason);
+    try {
+      await withTimeout(started.promise, 5000);
+      controller.abort(reason);
+      await withTimeout(rejection, 1000, "Initial abandonment did not observe the explicit signal");
+      if (phase === "RPC") await withTimeout(cancelled.promise, 5000);
+      expect(worker!["_completionAbortController"]!.signal.aborted).toBe(false);
+      expect(worker!["_abortController"]!.signal.aborted).toBe(false);
+      metadata.resolve(new grpc.Metadata());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(send).toHaveBeenCalledTimes(phase === "metadata" ? 0 : 1);
+      expect(activity).not.toHaveBeenCalled();
+    } finally {
+      controller.abort(reason);
+      metadata.resolve(new grpc.Metadata());
+      await rejection;
+    }
+  });
+
   it("bounds SDK delivery to ten attempts while preserving configured transport retries", async () => {
     const wait = ExponentialBackoff.prototype.wait;
     jest.spyOn(ExponentialBackoff.prototype, "wait").mockImplementation(function (

--- a/packages/durabletask-js/test/worker-response-delivery.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery.spec.ts
@@ -1,0 +1,404 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as grpc from "@grpc/grpc-js";
+import { EventEmitter, getEventListeners } from "events";
+import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
+import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
+import * as pb from "../src/proto/orchestrator_service_pb";
+import * as stubs from "../src/proto/orchestrator_service_grpc_pb";
+import { TaskEntity } from "../src/entities/task-entity";
+import { NoOpLogger } from "../src/types/logger.type";
+import { TaskHubGrpcWorker } from "../src/worker/task-hub-grpc-worker";
+import { VersionFailureStrategy, VersionMatchStrategy } from "../src/worker/versioning-options";
+
+function grpcError(code: grpc.status): grpc.ServiceError {
+  return Object.assign(new Error("injected delivery failure"), {
+    code,
+    details: "injected delivery failure",
+    metadata: new grpc.Metadata(),
+  });
+}
+
+function unaryCall(cancel = jest.fn()): grpc.ClientUnaryCall {
+  return Object.assign(new EventEmitter(), { cancel, getPeer: () => "test", getAuthContext: () => null });
+}
+
+type CompleteCallback = (error: grpc.ServiceError | null, response: pb.CompleteTaskResponse) => void;
+
+function createLogger() {
+  return { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+}
+
+describe("Worker response delivery", () => {
+  let stub: stubs.TaskHubSidecarServiceClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    stub = new stubs.TaskHubSidecarServiceClient("localhost:1", grpc.credentials.createInsecure());
+  });
+
+  afterEach(() => {
+    stub.close();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it.each([grpc.status.UNAVAILABLE, grpc.status.UNKNOWN, grpc.status.DEADLINE_EXCEEDED, grpc.status.INTERNAL])(
+    "retries status %s without re-executing the activity",
+    async (code) => {
+      const logger = createLogger();
+      const errorLog = jest.spyOn(logger, "error");
+      const worker = new TaskHubGrpcWorker({ logger });
+      const activity = jest.fn(() => "saved-result");
+      worker.addNamedActivity("deliveryActivity", activity);
+      const req = new pb.ActivityRequest();
+      req.setName("deliveryActivity");
+      req.setTaskid(42);
+      req.setOrchestrationinstance(new pb.OrchestrationInstance().setInstanceid("delivery-instance"));
+      const requests: pb.ActivityResponse[] = [];
+      const completeActivityTask = jest
+        .spyOn(stub, "completeActivityTask")
+        .mockImplementation(
+          (
+            response: pb.ActivityResponse,
+            _metadata: grpc.Metadata,
+            optionsOrCallback: Partial<grpc.CallOptions> | CompleteCallback,
+            callback?: CompleteCallback,
+          ) => {
+            requests.push(response);
+            const respond = typeof optionsOrCallback === "function" ? optionsOrCallback : callback!;
+            respond(requests.length < 3 ? grpcError(code) : null, new pb.CompleteTaskResponse());
+            return unaryCall();
+          },
+        );
+      // Exercise the real executor and response delivery, replacing only the network boundary.
+      const completion = worker["_executeActivityInternal"](req, "delivery-token", stub);
+
+      await jest.runAllTimersAsync();
+      await completion;
+
+      expect(completeActivityTask).toHaveBeenCalledTimes(3);
+      expect(activity).toHaveBeenCalledTimes(1);
+      expect(requests.every((response) => response === requests[0])).toBe(true);
+      expect(requests[0].getCompletiontoken()).toBe("delivery-token");
+      expect(requests[0].getResult()?.getValue()).toBe('"saved-result"');
+      expect(errorLog).not.toHaveBeenCalled();
+      expect(jest.getTimerCount()).toBe(0);
+    },
+  );
+
+  it.each([
+    grpc.status.CANCELLED,
+    grpc.status.INVALID_ARGUMENT,
+    grpc.status.NOT_FOUND,
+    grpc.status.ALREADY_EXISTS,
+    grpc.status.PERMISSION_DENIED,
+    grpc.status.RESOURCE_EXHAUSTED,
+    grpc.status.FAILED_PRECONDITION,
+    grpc.status.ABORTED,
+    grpc.status.OUT_OF_RANGE,
+    grpc.status.UNIMPLEMENTED,
+    grpc.status.DATA_LOSS,
+    grpc.status.UNAUTHENTICATED,
+    undefined,
+  ])("does not retry non-transient status %s", async (code) => {
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const error = code === undefined ? new Error("metadata failure") : grpcError(code);
+    const method = jest.fn(() => {
+      throw error;
+    });
+    await expect(worker["_deliverResponse"](stub, method, new pb.ActivityResponse())).rejects.toBe(error);
+    expect(method).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("bounds delivery to ten attempts with .NET backoff and returns the final error", async () => {
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const attempts: number[] = [];
+    const error = grpcError(grpc.status.UNAVAILABLE);
+    const method = jest.fn(() => {
+      attempts.push(Date.now());
+      throw error;
+    });
+    const delivery = worker["_deliverResponse"](stub, method, new pb.ActivityResponse());
+    const rejection = expect(delivery).rejects.toBe(error);
+    await jest.runAllTimersAsync();
+    await rejection;
+    expect(attempts.slice(1).map((time, i) => time - attempts[i])).toEqual([
+      200, 400, 800, 1600, 3200, 6400, 12800, 15000, 15000,
+    ]);
+    expect(method).toHaveBeenCalledTimes(10);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("uses positive jitter above the capped exponential delay", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.5);
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const attempts: number[] = [];
+    const method = jest.fn(() => {
+      attempts.push(Date.now());
+      throw grpcError(grpc.status.INTERNAL);
+    });
+    const rejection = expect(worker["_deliverResponse"](stub, method, new pb.ActivityResponse())).rejects.toThrow();
+    await jest.runAllTimersAsync();
+    await rejection;
+    expect(attempts.slice(1).map((time, i) => time - attempts[i])).toEqual([
+      220, 440, 880, 1760, 3520, 7040, 14080, 16500, 16500,
+    ]);
+  });
+
+  it("refreshes metadata on every delivery attempt", async () => {
+    const metadataGenerator = jest.fn(async () => new grpc.Metadata());
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger(), metadataGenerator });
+    const receivedMetadata: grpc.Metadata[] = [];
+    const method = (_request: pb.ActivityResponse, metadata: grpc.Metadata, callback: CompleteCallback) => {
+      receivedMetadata.push(metadata);
+      callback(receivedMetadata.length === 1 ? grpcError(grpc.status.INTERNAL) : null, new pb.CompleteTaskResponse());
+      return unaryCall();
+    };
+    const delivery = worker["_deliverResponse"](stub, method, new pb.ActivityResponse());
+    await jest.runAllTimersAsync();
+    await delivery;
+    expect(metadataGenerator).toHaveBeenCalledTimes(2);
+    expect(receivedMetadata[0]).not.toBe(receivedMetadata[1]);
+  });
+
+  it.each(["delay", "call"] as const)("cancels a retry %s and removes its resources", async (phase) => {
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const completion = new AbortController();
+    const retry = new AbortController();
+    worker["_responseDeliverySignals"].set(stub, { completion: completion.signal, retry: retry.signal });
+    const cancel = jest.fn();
+    let attempts = 0;
+    const method = (_req: pb.ActivityResponse, _metadata: grpc.Metadata, callback: CompleteCallback) => {
+      if (++attempts === 1) callback(grpcError(grpc.status.INTERNAL), new pb.CompleteTaskResponse());
+      return unaryCall(cancel);
+    };
+    const result = worker["_deliverResponse"](stub, method, new pb.ActivityResponse());
+    const rejection = expect(result).rejects.toThrow("stopped");
+    await jest.advanceTimersByTimeAsync(phase === "delay" ? 0 : 200);
+    retry.abort(new Error("stopped"));
+    await rejection;
+    expect(attempts).toBe(phase === "delay" ? 1 : 2);
+    expect(cancel).toHaveBeenCalledTimes(phase === "delay" ? 0 : 1);
+    expect(getEventListeners(completion.signal, "abort")).toHaveLength(0);
+    expect(getEventListeners(retry.signal, "abort")).toHaveLength(0);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("allows a draining first completion but does not retry after stop", async () => {
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const completion = new AbortController();
+    const retry = new AbortController();
+    worker["_responseDeliverySignals"].set(stub, { completion: completion.signal, retry: retry.signal });
+    retry.abort(new Error("stopped"));
+    const method = jest.fn((_req: pb.ActivityResponse, _metadata: grpc.Metadata, callback: CompleteCallback) => {
+      callback(null, new pb.CompleteTaskResponse());
+      return unaryCall();
+    });
+    await expect(worker["_deliverResponse"](stub, method, new pb.ActivityResponse())).resolves.toBeDefined();
+    expect(method).toHaveBeenCalledTimes(1);
+    completion.abort(new Error("drain expired"));
+    await expect(worker["_deliverResponse"](stub, method, new pb.ActivityResponse())).rejects.toThrow("drain expired");
+    expect(method).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the original stub until its pending work has delivered its response", async () => {
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const close = jest.spyOn(stub, "close");
+    let finish!: () => void;
+    const pending = new Promise<void>((resolve) => (finish = resolve));
+    worker["_trackPendingWorkItem"](stub, pending, () => {});
+    worker["_deferStubClose"](stub);
+    await jest.advanceTimersByTimeAsync(30000);
+    expect(close).not.toHaveBeenCalled();
+    finish();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(worker["_deferredStubCloseTimers"].size).toBe(0);
+  });
+
+  it("does not revive a stopped run's late response when a new run begins", async () => {
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    const oldCompletion = new AbortController();
+    const oldRetry = new AbortController();
+    worker["_responseDeliverySignals"].set(stub, {
+      completion: oldCompletion.signal,
+      retry: oldRetry.signal,
+    });
+    oldRetry.abort();
+    oldCompletion.abort();
+    worker["_completionAbortController"] = new AbortController();
+    worker["_abortController"] = new AbortController();
+    const method = jest.fn(() => unaryCall());
+    await expect(worker["_deliverResponse"](stub, method, new pb.ActivityResponse())).rejects.toThrow();
+    expect(method).not.toHaveBeenCalled();
+    expect(getEventListeners(oldCompletion.signal, "abort")).toHaveLength(0);
+    expect(getEventListeners(oldRetry.signal, "abort")).toHaveLength(0);
+  });
+
+  it("does not retain unrelated retired channels behind another channel's pending activity", async () => {
+    const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
+    let finish!: () => void;
+    const pending = new Promise<void>((resolve) => (finish = resolve));
+    worker.addNamedActivity("heldActivity", async () => pending);
+    const request = new pb.ActivityRequest().setName("heldActivity");
+    request.setOrchestrationinstance(new pb.OrchestrationInstance().setInstanceid("held-instance"));
+    jest
+      .spyOn(stub, "completeActivityTask")
+      .mockImplementation(
+        (
+          _response,
+          _metadata,
+          optionsOrCallback: Partial<grpc.CallOptions> | CompleteCallback,
+          callback?: CompleteCallback,
+        ) => {
+          const respond = typeof optionsOrCallback === "function" ? optionsOrCallback : callback!;
+          respond(null, new pb.CompleteTaskResponse());
+          return unaryCall();
+        },
+      );
+    const unrelatedStub = new stubs.TaskHubSidecarServiceClient("localhost:2", grpc.credentials.createInsecure());
+    const closeOwner = jest.spyOn(stub, "close");
+    const closeUnrelated = jest.spyOn(unrelatedStub, "close");
+    worker["_executeActivity"](request, "held-token", stub);
+    worker["_deferStubClose"](stub);
+    worker["_deferStubClose"](unrelatedStub);
+    try {
+      await jest.advanceTimersByTimeAsync(30000);
+      expect(closeOwner).not.toHaveBeenCalled();
+      expect(closeUnrelated).toHaveBeenCalledTimes(1);
+    } finally {
+      finish();
+      await jest.runAllTimersAsync();
+      unrelatedStub.close();
+    }
+    expect(closeOwner).toHaveBeenCalledTimes(1);
+    expect(worker["_pendingWorkItems"].size).toBe(0);
+  });
+
+  it("logs the final activity delivery failure after exhausting attempts", async () => {
+    const logger = createLogger();
+    const errorLog = jest.spyOn(logger, "error");
+    const worker = new TaskHubGrpcWorker({ logger });
+    const execution = jest.fn(() => {
+      throw new Error("activity failed");
+    });
+    worker.addNamedActivity("failingActivity", execution);
+    const request = new pb.ActivityRequest().setName("failingActivity").setTaskid(1);
+    request.setOrchestrationinstance(new pb.OrchestrationInstance().setInstanceid("failed-activity"));
+    const responses: pb.ActivityResponse[] = [];
+    jest
+      .spyOn(stub, "completeActivityTask")
+      .mockImplementation(
+        (
+          response,
+          _metadata,
+          optionsOrCallback: Partial<grpc.CallOptions> | CompleteCallback,
+          callback?: CompleteCallback,
+        ) => {
+          responses.push(response);
+          const respond = typeof optionsOrCallback === "function" ? optionsOrCallback : callback!;
+          respond(grpcError(grpc.status.INTERNAL), new pb.CompleteTaskResponse());
+          return unaryCall();
+        },
+      );
+    const completion = worker["_executeActivityInternal"](request, "failure-token", stub);
+    await jest.runAllTimersAsync();
+    await completion;
+    expect(responses).toHaveLength(10);
+    expect(responses.every((response) => response === responses[0])).toBe(true);
+    expect(responses[0].getFailuredetails()?.getErrormessage()).toBe("activity failed");
+    expect(execution).toHaveBeenCalledTimes(1);
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("injected delivery failure"));
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it.each(["orchestrator", "version-fail", "abandon", "entity-v1", "entity-v2", "entity-missing"] as const)(
+    "retries the same %s response without repeating user execution",
+    async (kind) => {
+      const logger = createLogger();
+      const errorLog = jest.spyOn(logger, "error");
+      const worker = new TaskHubGrpcWorker({
+        logger,
+        versioning:
+          kind === "version-fail" || kind === "abandon"
+            ? {
+                version: "2",
+                matchStrategy: VersionMatchStrategy.Strict,
+                failureStrategy: kind === "abandon" ? VersionFailureStrategy.Reject : VersionFailureStrategy.Fail,
+              }
+            : undefined,
+      });
+      const executed = jest.fn();
+      worker.addNamedOrchestrator("deliveryOrchestrator", async () => {
+        executed();
+        return "orchestration-result";
+      });
+      class Counter extends TaskEntity<number> {
+        increment(): number {
+          executed();
+          return ++this.state;
+        }
+        protected initializeState(): number {
+          return 0;
+        }
+      }
+      if (kind !== "entity-missing") worker.addNamedEntity("deliveryCounter", () => new Counter());
+      const requests: Array<pb.OrchestratorResponse | pb.EntityBatchResult | pb.AbandonOrchestrationTaskRequest> = [];
+      const method = kind.startsWith("entity")
+        ? "completeEntityTask"
+        : kind === "abandon"
+          ? "abandonTaskOrchestratorWorkItem"
+          : "completeOrchestratorTask";
+      jest
+        .spyOn(stub, method)
+        .mockImplementation(
+          (
+            response,
+            _metadata,
+            optionsOrCallback: Partial<grpc.CallOptions> | CompleteCallback,
+            callback?: CompleteCallback,
+          ) => {
+            requests.push(response);
+            const respond = typeof optionsOrCallback === "function" ? optionsOrCallback : callback!;
+            respond(requests.length === 1 ? grpcError(grpc.status.INTERNAL) : null, new pb.CompleteTaskResponse());
+            return unaryCall();
+          },
+        );
+      let delivery: Promise<void>;
+      if (kind.startsWith("entity")) {
+        if (kind === "entity-v2") {
+          const req = new pb.EntityRequest().setInstanceid("@deliverycounter@key");
+          const operation = new pb.EntityOperationSignaledEvent().setOperation("increment").setRequestid("req-1");
+          req.setOperationrequestsList([new pb.HistoryEvent().setEntityoperationsignaled(operation)]);
+          delivery = worker["_executeEntityV2Internal"](req, "response-token", stub);
+        } else {
+          const req = new pb.EntityBatchRequest().setInstanceid("@deliverycounter@key");
+          req.setOperationsList([new pb.OperationRequest().setOperation("increment").setRequestid("req-1")]);
+          delivery = worker["_executeEntityInternal"](req, "response-token", stub);
+        }
+      } else {
+        const req = new pb.OrchestratorRequest().setInstanceid("delivery-instance");
+        const started = new pb.ExecutionStartedEvent().setName("deliveryOrchestrator");
+        started.setVersion(new StringValue().setValue("1"));
+        req.setNeweventsList([
+          new pb.HistoryEvent()
+            .setTimestamp(Timestamp.fromDate(new Date()))
+            .setOrchestratorstarted(new pb.OrchestratorStartedEvent()),
+          new pb.HistoryEvent().setExecutionstarted(started),
+        ]);
+        delivery = worker["_executeOrchestratorInternal"](req, "response-token", stub);
+      }
+      await jest.runAllTimersAsync();
+      await delivery;
+      expect(requests).toHaveLength(2);
+      expect(requests[1]).toBe(requests[0]);
+      expect(requests[0].getCompletiontoken()).toBe("response-token");
+      expect(executed).toHaveBeenCalledTimes(["abandon", "version-fail", "entity-missing"].includes(kind) ? 0 : 1);
+      if (kind !== "entity-missing" && kind !== "version-fail") expect(errorLog).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/durabletask-js/test/worker-response-delivery.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery.spec.ts
@@ -205,6 +205,69 @@ describe("Worker response delivery", () => {
     expect(method).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["initial metadata", "initial RPC", "backoff", "retry metadata", "retry RPC"])(
+    "uses an explicit delivery signal during %s",
+    async (phase) => {
+      let resolveMetadata!: (metadata: grpc.Metadata) => void;
+      const heldMetadata = new Promise<grpc.Metadata>((resolve) => (resolveMetadata = resolve));
+      let metadataCalls = 0;
+      const metadataGenerator = jest.fn(async () => {
+        metadataCalls++;
+        if (phase === "initial metadata" || (phase === "retry metadata" && metadataCalls === 2)) {
+          return heldMetadata;
+        }
+        return new grpc.Metadata();
+      });
+      const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger(), metadataGenerator });
+      const completion = new AbortController();
+      const retry = new AbortController();
+      const explicit = new AbortController();
+      worker["_responseDeliverySignals"].set(stub, { completion: completion.signal, retry: retry.signal });
+      const cancel = jest.fn();
+      let attempts = 0;
+      const method = (_req: pb.ActivityResponse, _metadata: grpc.Metadata, callback: CompleteCallback) => {
+        if (++attempts === 1 && (phase === "backoff" || phase.startsWith("retry"))) {
+          callback(grpcError(grpc.status.INTERNAL), new pb.CompleteTaskResponse());
+        }
+        return unaryCall(cancel);
+      };
+      let settled = false;
+      let error: unknown;
+      const delivery = worker["_deliverResponse"](stub, method, new pb.ActivityResponse(), explicit.signal).then(
+        () => (settled = true),
+        (reason: unknown) => {
+          error = reason;
+          settled = true;
+        },
+      );
+      try {
+        await jest.advanceTimersByTimeAsync(phase.startsWith("retry") ? 200 : 0);
+        const sent = attempts;
+        const reason = new Error("explicitly stopped");
+        explicit.abort(reason);
+        await jest.advanceTimersByTimeAsync(0);
+        expect(settled).toBe(true);
+        expect(error).toBe(reason);
+        expect(completion.signal.aborted).toBe(false);
+        expect(retry.signal.aborted).toBe(false);
+        resolveMetadata(new grpc.Metadata());
+        await jest.runAllTimersAsync();
+        expect(attempts).toBe(sent);
+        expect(cancel).toHaveBeenCalledTimes(phase.endsWith("RPC") ? 1 : 0);
+        expect(getEventListeners(explicit.signal, "abort")).toHaveLength(0);
+        expect(getEventListeners(completion.signal, "abort")).toHaveLength(0);
+        expect(getEventListeners(retry.signal, "abort")).toHaveLength(0);
+        expect(jest.getTimerCount()).toBe(0);
+      } finally {
+        completion.abort();
+        retry.abort();
+        resolveMetadata(new grpc.Metadata());
+        await jest.runAllTimersAsync();
+        await delivery;
+      }
+    },
+  );
+
   it.each(["initial", "retry"] as const)("cancels pending %s metadata at its shutdown boundary", async (phase) => {
     let resolveMetadata!: (metadata: grpc.Metadata) => void;
     const heldMetadata = new Promise<grpc.Metadata>((resolve) => (resolveMetadata = resolve));

--- a/packages/durabletask-js/test/worker-response-delivery.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery.spec.ts
@@ -205,6 +205,72 @@ describe("Worker response delivery", () => {
     expect(method).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["initial", "retry"] as const)("cancels pending %s metadata at its shutdown boundary", async (phase) => {
+    let resolveMetadata!: (metadata: grpc.Metadata) => void;
+    const heldMetadata = new Promise<grpc.Metadata>((resolve) => (resolveMetadata = resolve));
+    const metadataGenerator = jest.fn(() => heldMetadata);
+    if (phase === "retry") metadataGenerator.mockResolvedValueOnce(new grpc.Metadata());
+    const logger = createLogger();
+    const worker = new TaskHubGrpcWorker({ logger, metadataGenerator, shutdownTimeoutMs: 1000 });
+    const activity = jest.fn(() => "activity-result");
+    worker.addNamedActivity("metadataActivity", activity);
+    const completion = new AbortController();
+    const retry = new AbortController();
+    worker["_isRunning"] = true;
+    worker["_stub"] = stub;
+    worker["_completionAbortController"] = completion;
+    worker["_abortController"] = retry;
+    worker["_responseDeliverySignals"].set(stub, { completion: completion.signal, retry: retry.signal });
+    const method = jest
+      .spyOn(stub, "completeActivityTask")
+      .mockImplementation(
+        (
+          _response,
+          _metadata,
+          optionsOrCallback: Partial<grpc.CallOptions> | CompleteCallback,
+          callback?: CompleteCallback,
+        ) => {
+          const respond = typeof optionsOrCallback === "function" ? optionsOrCallback : callback!;
+          respond(grpcError(grpc.status.INTERNAL), new pb.CompleteTaskResponse());
+          return unaryCall();
+        },
+      );
+    const request = new pb.ActivityRequest()
+      .setName("metadataActivity")
+      .setOrchestrationinstance(new pb.OrchestrationInstance().setInstanceid("metadata-instance"));
+    worker["_executeActivity"](request, "metadata-token", stub);
+    await jest.advanceTimersByTimeAsync(200);
+    expect(metadataGenerator).toHaveBeenCalledTimes(phase === "initial" ? 1 : 2);
+    expect(worker["_pendingWorkItems"].size).toBe(1);
+
+    const stopping = worker.stop();
+    try {
+      await jest.advanceTimersByTimeAsync(0);
+      if (phase === "initial") {
+        await jest.advanceTimersByTimeAsync(999);
+        expect(completion.signal.aborted).toBe(false);
+        expect(worker["_pendingWorkItems"].size).toBe(1);
+        await jest.advanceTimersByTimeAsync(1);
+      }
+      expect(worker["_pendingWorkItems"].size).toBe(0);
+      expect(worker["_pendingWorkItemsByStub"].get(stub)?.size).toBe(0);
+      expect(getEventListeners(completion.signal, "abort")).toHaveLength(0);
+      expect(getEventListeners(retry.signal, "abort")).toHaveLength(0);
+
+      resolveMetadata(new grpc.Metadata());
+      await jest.runAllTimersAsync();
+      await stopping;
+      expect(method).toHaveBeenCalledTimes(phase === "initial" ? 0 : 1);
+      expect(activity).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledTimes(phase === "initial" ? 1 : 0);
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      resolveMetadata(new grpc.Metadata());
+      await jest.runAllTimersAsync();
+      await stopping;
+    }
+  });
+
   it("retains the original stub until its pending work has delivered its response", async () => {
     const worker = new TaskHubGrpcWorker({ logger: new NoOpLogger() });
     const close = jest.spyOn(stub, "close");

--- a/packages/durabletask-js/test/worker-response-delivery.spec.ts
+++ b/packages/durabletask-js/test/worker-response-delivery.spec.ts
@@ -24,7 +24,10 @@ function unaryCall(cancel = jest.fn()): grpc.ClientUnaryCall {
   return Object.assign(new EventEmitter(), { cancel, getPeer: () => "test", getAuthContext: () => null });
 }
 
-type CompleteCallback = (error: grpc.ServiceError | null, response: pb.CompleteTaskResponse) => void;
+type CompleteCallback<TResponse = pb.CompleteTaskResponse> = (
+  error: grpc.ServiceError | null,
+  response: TResponse,
+) => void;
 
 function createLogger() {
   return { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
@@ -488,12 +491,16 @@ describe("Worker response delivery", () => {
           (
             response,
             _metadata,
-            optionsOrCallback: Partial<grpc.CallOptions> | CompleteCallback,
-            callback?: CompleteCallback,
+            optionsOrCallback:
+              | Partial<grpc.CallOptions>
+              | CompleteCallback<pb.CompleteTaskResponse | pb.AbandonOrchestrationTaskResponse>,
+            callback?: CompleteCallback<pb.CompleteTaskResponse | pb.AbandonOrchestrationTaskResponse>,
           ) => {
             requests.push(response);
             const respond = typeof optionsOrCallback === "function" ? optionsOrCallback : callback!;
-            respond(requests.length === 1 ? grpcError(grpc.status.INTERNAL) : null, new pb.CompleteTaskResponse());
+            const result =
+              kind === "abandon" ? new pb.AbandonOrchestrationTaskResponse() : new pb.CompleteTaskResponse();
+            respond(requests.length === 1 ? grpcError(grpc.status.INTERNAL) : null, result);
             return unaryCall();
           },
         );

--- a/packages/durabletask-js/test/worker-startup.spec.ts
+++ b/packages/durabletask-js/test/worker-startup.spec.ts
@@ -229,13 +229,15 @@ describe("TaskHubGrpcWorker startup", () => {
     await failStream(streams[1]);
 
     expect(clientOptions).toEqual([
-      { "grpc.keepalive_time_ms": 1234 },
+      { "grpc.keepalive_time_ms": 1234, "grpc.enable_retries": 0 },
       {
         "grpc.keepalive_time_ms": 1234,
+        "grpc.enable_retries": 0,
         "grpc.use_local_subchannel_pool": 1,
       },
       {
         "grpc.keepalive_time_ms": 1234,
+        "grpc.enable_retries": 0,
         "grpc.use_local_subchannel_pool": 1,
       },
     ]);

--- a/packages/durabletask-js/test/worker-startup.spec.ts
+++ b/packages/durabletask-js/test/worker-startup.spec.ts
@@ -229,15 +229,13 @@ describe("TaskHubGrpcWorker startup", () => {
     await failStream(streams[1]);
 
     expect(clientOptions).toEqual([
-      { "grpc.keepalive_time_ms": 1234, "grpc.enable_retries": 0 },
+      { "grpc.keepalive_time_ms": 1234 },
       {
         "grpc.keepalive_time_ms": 1234,
-        "grpc.enable_retries": 0,
         "grpc.use_local_subchannel_pool": 1,
       },
       {
         "grpc.keepalive_time_ms": 1234,
-        "grpc.enable_retries": 0,
         "grpc.use_local_subchannel_pool": 1,
       },
     ]);

--- a/test/e2e-azuremanaged/worker-response-delivery.spec.ts
+++ b/test/e2e-azuremanaged/worker-response-delivery.spec.ts
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as grpc from "@grpc/grpc-js";
+import { randomUUID } from "crypto";
+import {
+  ActivityContext,
+  EntityInstanceId,
+  Logger,
+  OrchestrationContext,
+  ProtoOrchestrationStatus,
+  Task,
+  TaskEntity,
+} from "@microsoft/durabletask-js";
+import {
+  DurableTaskAzureManagedClientBuilder,
+  DurableTaskAzureManagedWorkerBuilder,
+} from "@microsoft/durabletask-js-azuremanaged";
+import * as pb from "../../packages/durabletask-js/src/proto/orchestrator_service_pb";
+
+// Opt-in: use a dedicated existing task hub. This suite never provisions or deletes Azure resources.
+const connectionString = process.env.WORKER_DELIVERY_CONNECTION_STRING;
+const describeDelivery = connectionString ? describe : describe.skip;
+
+describeDelivery("Worker response delivery with a real scheduler", () => {
+  it.each([false, true])(
+    "persists orchestration and entity results (injected delivery failures: %s)",
+    async (inject) => {
+      const runId = `response-delivery-${randomUUID()}`;
+      const attempts = new Map<string, number>();
+      const payloads = new Map<string, Buffer>();
+      const methods = new Map<string, string>();
+      let injectedFailures = 0;
+      let activityExecutions = 0;
+      let entityExecutions = 0;
+      const errors: string[] = [];
+      const logger: Logger = {
+        error: (message) => errors.push(message),
+        warn: () => {},
+        info: () => {},
+        debug: () => {},
+      };
+
+      const interceptor: grpc.Interceptor = (options, nextCall) => {
+        if (!/\/Complete(Orchestrator|Activity|Entity)Task$/.test(options.method_definition.path)) {
+          return new grpc.InterceptingCall(nextCall(options));
+        }
+        let begin: (() => void) | undefined;
+        let fail: (() => void) | undefined;
+        let forwarded = false;
+        return new grpc.InterceptingCall(nextCall(options), {
+          start(metadata, listener, next) {
+            begin = () => next(metadata, listener);
+            fail = () =>
+              listener.onReceiveStatus({
+                code: grpc.status.INTERNAL,
+                details: "Test-only pre-send delivery fault; not an Azure outage",
+                metadata: new grpc.Metadata(),
+              });
+          },
+          sendMessage(message: pb.OrchestratorResponse | pb.ActivityResponse | pb.EntityBatchResult, next) {
+            const key = `${options.method_definition.path}:${message.getCompletiontoken()}`;
+            const attempt = (attempts.get(key) ?? 0) + 1;
+            attempts.set(key, attempt);
+            methods.set(key, options.method_definition.path);
+            const bytes = Buffer.from(message.serializeBinary());
+            if (payloads.has(key)) expect(bytes).toEqual(payloads.get(key));
+            else payloads.set(key, bytes);
+            if (inject && attempt === 1) {
+              injectedFailures++;
+              fail!();
+            } else {
+              forwarded = true;
+              begin!();
+              next(message);
+            }
+          },
+          halfClose(next) {
+            if (forwarded) next();
+          },
+        });
+      };
+
+      const activityName = `DeliveryActivity-${runId}`;
+      const orchestrationName = `DeliveryOrchestrator-${runId}`;
+      const entityName = `DeliveryCounter-${runId}`;
+      const entityId = new EntityInstanceId(entityName, "counter");
+      const activity = (_context: ActivityContext, input: number): number => {
+        activityExecutions++;
+        return input + 1;
+      };
+      const orchestration = async function* (
+        context: OrchestrationContext,
+      ): AsyncGenerator<Task<number>, number, number> {
+        const result = yield context.callActivity(activityName, 41);
+        return result;
+      };
+      class Counter extends TaskEntity<number> {
+        add(value: number): void {
+          entityExecutions++;
+          this.state += value;
+        }
+        protected initializeState(): number {
+          return 0;
+        }
+      }
+
+      const client = new DurableTaskAzureManagedClientBuilder()
+        .connectionString(connectionString!)
+        .logger(logger)
+        .build();
+      const worker = new DurableTaskAzureManagedWorkerBuilder()
+        .connectionString(connectionString!)
+        .grpcChannelOptions({ interceptors: [interceptor] })
+        .logger(logger)
+        .useWorkItemFilters()
+        .build();
+      worker.addNamedActivity(activityName, activity);
+      worker.addNamedOrchestrator(orchestrationName, orchestration);
+      worker.addNamedEntity(entityName, () => new Counter());
+      try {
+        await worker.start();
+        await client.scheduleNewOrchestration(orchestrationName, undefined, { instanceId: runId });
+        await client.signalEntity(entityId, "add", 42);
+        const state = await client.waitForOrchestrationCompletion(runId, true, 60);
+        expect(state?.runtimeStatus).toBe(ProtoOrchestrationStatus.ORCHESTRATION_STATUS_COMPLETED);
+        expect(state?.serializedOutput).toBe("42");
+        let entity = await client.getEntity<number>(entityId);
+        const deadline = Date.now() + 30000;
+        while (entity?.state !== 42 && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          entity = await client.getEntity<number>(entityId);
+        }
+        expect(entity?.state).toBe(42);
+        expect(activityExecutions).toBe(1);
+        expect(entityExecutions).toBe(1);
+        expect(errors).toEqual([]);
+        expect(new Set(methods.values())).toEqual(
+          new Set([
+            "/TaskHubSidecarService/CompleteOrchestratorTask",
+            "/TaskHubSidecarService/CompleteActivityTask",
+            "/TaskHubSidecarService/CompleteEntityTask",
+          ]),
+        );
+        expect([...attempts.values()].every((count) => count === (inject ? 2 : 1))).toBe(true);
+        expect(injectedFailures).toBe(inject ? attempts.size : 0);
+        // Do not print completion tokens or credentials in evidence logs.
+        console.log(
+          JSON.stringify({
+            runId,
+            entityId: entityId.toString(),
+            injected: inject,
+            injectionLocation: inject ? "client interceptor, before sending to real scheduler" : "none",
+            status: "Completed",
+            output: state?.serializedOutput,
+            entityState: entity?.state,
+            activityExecutions,
+            entityExecutions,
+            injectedFailures,
+            deliveries: [...attempts].map(([key, count]) => ({ method: methods.get(key), attempts: count })),
+          }),
+        );
+      } finally {
+        await worker.stop();
+        await client.stop();
+      }
+    },
+    120000,
+  );
+});


### PR DESCRIPTION
# Summary

## What changed?
- Add one shared worker delivery loop for orchestration/activity/entity completion, version-mismatch failure completion, and orchestration abandonment. Retry the same response/token, never user execution.
- Match .NET's **10 SDK attempts** for `UNAVAILABLE`, `UNKNOWN`, `DEADLINE_EXCEEDED`, and `INTERNAL`: 200 ms exponential backoff, capped at 15 seconds before +0–20% jitter. Permanent/exhausted failures retain existing error logs.
- Cancel retry waits/retried RPCs on stop while allowing initial completion during the existing graceful-drain window. Retired stubs wait only for their own pending work; original-run cancellation survives reconnect/restart.
- Make the existing unary helper's metadata wait abort-aware, with cleanup and no late RPC after cancellation.
- Route version rejection through private `_abandonOrchestrationWorkItem(stub, completionToken, signal?)`, backed by the same delivery loop. An explicit signal governs initial attempts, retries and backoff; omission preserves graceful-initial/retry-stop behavior. This provides the shared primitive for the independently based history PR, not another retry framework.
- **Preserve caller channel options and Azure-managed transport retry configuration**, matching the .NET Azure-managed worker. Ten SDK attempts is not a ten-physical-request guarantee.
- Explicitly run both real-socket and persisted-backend delivery specs in the existing DTS emulator group on **Node 22/24**. The backend suite remains opt-in locally; CI supplies its emulator connection string.

## Why is this change needed?
Azure-managed workers already configure transport retries, normally for UNAVAILABLE. Core completion/abandon sites lack a bounded SDK delivery loop, including after headers commit and for additional .NET transient statuses. This closes that gap without changing persisted history or the backend's at-least-once work-item delivery contract.

Pinned reference: `microsoft/durabletask-dotnet@bc2bc12ca5ee3a12a6e633250ade5efe6ae90ef4`, processor `ExecuteWithRetryAsync`, internal options, and `GrpcBackoff.cs`. Its Azure-managed `CreateChannel` also retains `GrpcRetryPolicyDefaults.DefaultServiceConfig` beneath that loop, confirming the layered retry behavior.

Base: upstream main `28730dfaedaecd696468cae2e2365153b230fa56`. **Final tested head: `4ce281c32f46ca806fcd39acc8f86b2a8b1e7abe`. All final-head CI workflows passed. The coordinator's principal source re-review approved this exact head, including the shared-abandonment delta; no remaining source blocker.**

## Issues / work items
- Focused worker-response parity change. No client wait feature, history hydration, chunking, or concurrency implementation.

---

# Project checklist
- [ ] Release notes are not required for the next release
  - [x] Otherwise: Notes added to `CHANGELOG.md`
- [x] Backport is not required
  - [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
- [x] All required tests have been added/updated (unit tests, E2E tests)
- [ ] Breaking change?
  - [ ] If yes:
    - Impact: No public API/wire-format changes; existing channel configuration is preserved.
    - Migration guidance: Account for both SDK and configured transport retry layers as documented in README.

---

# AI-assisted code disclosure (required)

## Was an AI tool used? (select one)
- [ ] No
- [ ] Yes, AI helped write parts of this PR (e.g., GitHub Copilot)
- [x] Yes, an AI agent generated most of this PR

If AI was used:
- Tool(s): GitHub Copilot CLI.
- AI-assisted areas/files: Implementation, tests, CI selector wiring, documentation.
- What you changed after AI output: Restricted channel retention to per-stub work; wired explicit CI coverage; removed a transport-retry override after inspecting .NET layering; fixed pending metadata cancellation; extracted shared abandonment to close a concrete cross-PR coverage gap. Principal source re-review approved the final head; human confirmation below remains separate.

AI verification (required if AI was used):
- [ ] I understand the code and can explain it (human confirmation pending)
- [x] I verified referenced APIs/types exist and are correct
- [x] I reviewed edge cases/failure paths (timeouts, retries, cancellation, exceptions)
- [x] I reviewed concurrency/async behavior
- [x] I checked for unintended breaking or behavior changes

---

# Testing

## Automated tests
- **404 passed / 19 local suites at final head**, using existing Jest: `npx --no-install jest --runInBand --runTestsByPath ... --detectOpenHandles`. Covers affected worker/versioning/entity/tracing/host-integration/backoff behavior, Azure-managed builder/retry/options/endpoint behavior, and client regressions for the shared unary helper.
- Includes **21 real-gRPC socket cases**, using OS-assigned loopback ports: committed-header transient failures, permanent failures, bounded delivery, shutdown metadata/RPC/backoff cancellation, graceful initial completion, all existing completion/abandon paths, reconnect ownership, and explicit-signal abandonment.
- Five explicit-signal tests first failed during initial metadata/RPC, backoff and retry metadata/RPC; they now pass. New socket cases prove transient abandonment reuses its payload/token and explicit cancellation stops initial metadata/RPC immediately. Default drain tests remain unchanged.
- Metadata regressions first failed with pending work stuck at one. They now assert cleanup before metadata resolves, preserved initial drain, and no late RPC.
- Configured retry-layer proof: **10 SDK calls and 50 actual server calls** under a five-attempt INTERNAL channel policy, observing transport attempt metadata and one user activity execution. Only delay duration is shortened; separate deterministic tests verify exact backoff.
- **All final-head CI workflows passed**: [Test and Build](https://github.com/microsoft/durabletask-js/actions/runs/34256188373), [DTS Emulator E2E](https://github.com/microsoft/durabletask-js/actions/runs/34256188477), [Validate Samples](https://github.com/microsoft/durabletask-js/actions/runs/34256188345).
- Final DTS delivery-group jobs on [Node 22](https://github.com/microsoft/durabletask-js/actions/runs/34256188477/job/102162486264) and [Node 24](https://github.com/microsoft/durabletask-js/actions/runs/34256188477/job/102162486351) each passed **61 tests / 6 suites, zero skipped**, explicitly including both delivery specs and real emulator persisted outcomes.
- `npm run build:core`, `npm run build:azuremanaged`, changed TS ESLint/Prettier and `git diff --check`: passed. Changelog/workflow formatting passed previously and those files are unchanged by the latest delta. README's pre-existing whole-file formatting was not rewritten.

## Manual validation (only if runtime/behavior changed)
- Windows, Node.js v24.14.0; **real HTTPS Azure DTS Consumption, westus2, dedicated `workerresponse` task hub**, Azure CLI authentication. No Azure resources created/deleted; no combined-run hub access.
- Final-head command: `npx --no-install jest --runInBand --runTestsByPath test/e2e-azuremanaged/worker-response-delivery.spec.ts --detectOpenHandles`, with the dedicated `WORKER_DELIVERY_CONNECTION_STRING`. **2 passed**.

### Real Azure baseline — no injection
- Orchestration: `response-delivery-2ba5d9c0-a76e-49e1-905d-1985050d0a41`.
- Entity: `@deliverycounter-response-delivery-2ba5d9c0-a76e-49e1-905d-1985050d0a41@counter`.
- Persisted `Completed`, output `42`, entity state `42`; activity/entity each executed once.
- Four completion payloads (orchestrator x2, activity x1, entity x1), **one SDK attempt each**.

### Real Azure persisted outcome with controlled client-side faults
- Orchestration: `response-delivery-1b138691-3b2a-40aa-893e-4b2db2ba5c41`.
- Entity: `@deliverycounter-response-delivery-1b138691-3b2a-40aa-893e-4b2db2ba5c41@counter`.
- Persisted `Completed`, output `42`, entity state `42`; activity/entity each executed once.
- Four pre-send INTERNAL injections, one per completion payload; **two SDK attempts per payload**. Serialized payloads/completion tokens asserted identical across retries.
- Injection is a **test client interceptor before forwarding to real Azure**, not an actual Azure outage. SDK invocation counts are not physical network-attempt counts. Actual server-side faults and explicit-signal abandonment are covered separately by the socket suite.

---

# Notes for reviewers
- **Companion history-PR merge resolution:** both independently based PRs define `private async _abandonOrchestrationWorkItem(stub, completionToken, signal?): Promise<void>`. Keep **this PR's retry-backed helper body** and **both history-PR callers**. The history-fetch-error caller supplies its immediate-stop signal; version rejection omits it. Do not retain the history PR's standalone direct-`callWithMetadata` helper body in the combined tree, or that path bypasses response retries. Combined history-error + transient-abandon fault coverage is owned by integration; this standalone PR does not add history fetching.
- The SDK bound is an attempt bound, not a new per-RPC wall-clock deadline. Existing transport retries may multiply underlying attempts.
- Initial completion stays graceful by default; explicitly supplied abandonment cancellation covers every phase immediately. Metadata generation itself has no cancellation argument and may continue, but cannot cause a late RPC.
- Backend redelivery can still rerun user code; exactly-once assertions concern retries of a single response delivery only.
- Commit-hook shell execution hit unavailable WSL Bash; the identical `npx --no-install lint-staged` check passed when run directly before committing.
